### PR TITLE
Feature/refresh scimma auth api token

### DIFF
--- a/hermes/brokers/hopskotch.py
+++ b/hermes/brokers/hopskotch.py
@@ -235,7 +235,7 @@ def authorize_user(username: str, hermes_api_token: str) -> Auth:
     # create user SCRAM credential (hop.auth.Auth instance)
     user_hop_auth: Auth = get_user_hop_authorization(username, user_api_token)
     logger.info(f'authorize_user SCRAM credential created for {username}:  {user_hop_auth.username}')
-    credential_pk = _get_hop_credential_pk(username, user_hop_auth.username, user_pk=user_pk, user_api_token=user_api_token)
+    credential_pk = _get_hop_credential_pk(username, user_hop_auth.username, user_api_token=user_api_token, user_pk=user_pk)
 
     add_permissions_to_credential(username, user_pk, credential_pk, user_api_token=user_api_token)
 

--- a/hermes/middleware.py
+++ b/hermes/middleware.py
@@ -1,0 +1,84 @@
+import logging
+import datetime
+
+from django.utils import dateparse
+
+from hermes.brokers import hopskotch
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+class SCiMMAAuthSessionRefresh:
+    def __init__(self, get_response):
+        self.get_response = get_response
+        # One-time configuration and initialization.
+
+    def _is_expired(self, expiration: datetime.datetime) -> bool:
+        """Return True if expiration is in the past, or within the next 15 minutes.
+
+        Reminder: datetimes grow into the future. So, datetime.datetime.now()
+        is less than future datetimes. Or, if now() is greater than an expiration
+        datetime, then that expiration datetime is in the past (expired).
+        """
+        some_mintues_from_now = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(minutes=15)
+        return some_mintues_from_now > expiration # > means True if expiration is in past
+
+
+    def refresh_hermes_token(self, request):
+        logger.debug(f'Refreshing SCiMMA Auth API token for Hermes service account.')
+        hermes_api_token, hermes_api_token_expiration = hopskotch.get_hermes_api_token()
+        request.session['hermes_api_token'] = hermes_api_token
+        request.session['hermes_api_token_expiration'] = hermes_api_token_expiration
+
+
+    def refresh_user_token(self, request):
+        """Refresh the SCiMMA Auth User API token in the request.session.
+
+        We might need to refresh the Hermes service account SCiMMA Auth API token along the way,
+        since admin privilidges are required to get the User API token
+        """
+        logger.debug(f'Refreshing SCiMMA Auth API token for User.')
+        hermes_api_token_expiration_str: str = request.session.get('hermes_api_token_expiration', None)
+        if hermes_api_token_expiration_str:
+            hermes_api_token_expiration: datetime.datetime = dateparse.parse_datetime(hermes_api_token_expiration_str)
+            need_new_hermes_api_token = self._is_expired(hermes_api_token_expiration)
+        else:
+            need_new_hermes_api_token = True
+        
+        if need_new_hermes_api_token:
+            logger.debug(f'New SCiMMA Auth API token for Hermes service account needed.')
+            self.refresh_hermes_token(request)
+        else:
+            logger.debug(f'SCiMMA Auth API token for Hermes service account up-to-date.')
+        
+        username = request.user.username
+        hermes_api_token = request.session['hermes_api_token']
+        user_api_token, user_api_token_expiration = hopskotch.get_user_api_token(username, hermes_api_token)
+        request.session['user_api_token'] = user_api_token
+        request.session['user_api_token_expiration'] = user_api_token_expiration
+
+
+    def __call__(self, request):
+        # Code to be executed for each request before
+        # the view (and later middleware) are called.
+        logger.debug(f'maintaining SCiMMA Auth API tokens in Session...')
+
+        user_api_token_expiration_str: str = request.session.get('user_api_token_expiration', None)
+        if user_api_token_expiration_str:
+            user_api_token_expiration: datetime.datetime = dateparse.parse_datetime(user_api_token_expiration_str)
+            need_new_user_api_token = self._is_expired(user_api_token_expiration)
+        else:
+            need_new_user_api_token = True
+        
+        if need_new_user_api_token:
+            logger.debug(f'New SCiMMA Auth API user token needed.')
+            self.refresh_user_token(request)
+        else:
+            logger.debug(f'SCiMMA Auth API token for {request.user.username} up-to-date.')
+
+        response = self.get_response(request)
+
+        # Code to be executed for each request/response after
+        # the view is called.
+
+        return response

--- a/hermes/middleware.py
+++ b/hermes/middleware.py
@@ -6,12 +6,11 @@ from django.utils import dateparse
 from hermes.brokers import hopskotch
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
+#logger.setLevel(logging.DEBUG)
 
 class SCiMMAAuthSessionRefresh:
     def __init__(self, get_response):
         self.get_response = get_response
-        # One-time configuration and initialization.
 
     def _is_expired(self, expiration: datetime.datetime) -> bool:
         """Return True if expiration is in the past, or within the next 15 minutes.
@@ -38,6 +37,8 @@ class SCiMMAAuthSessionRefresh:
         since admin privilidges are required to get the User API token
         """
         logger.debug(f'Refreshing SCiMMA Auth API token for User.')
+
+        # get the hermes service account API token and check it's expiration status
         hermes_api_token_expiration_str: str = request.session.get('hermes_api_token_expiration', None)
         if hermes_api_token_expiration_str:
             hermes_api_token_expiration: datetime.datetime = dateparse.parse_datetime(hermes_api_token_expiration_str)
@@ -76,7 +77,7 @@ class SCiMMAAuthSessionRefresh:
         else:
             logger.debug(f'SCiMMA Auth API token for {request.user.username} up-to-date.')
 
-        response = self.get_response(request)
+        response = self.get_response(request)  # pass the request to the next Middleware in the list
 
         # Code to be executed for each request/response after
         # the view is called.

--- a/hermes/views.py
+++ b/hermes/views.py
@@ -191,7 +191,7 @@ class TopicViewSet(viewsets.ViewSet):
             return JsonResponse(data=default_topics)
 
         credential_name = user_hop_auth.username
-        user_api_token = hopskotch.get_user_api_token(username)
+        user_api_token = request.session['user_api_token']  # maintained in middleware
 
         topics = hopskotch.get_user_topic_permissions(username, credential_name, user_api_token,
                                                       exclude_groups=['sys'])

--- a/hermes_base/settings.py
+++ b/hermes_base/settings.py
@@ -61,6 +61,7 @@ MIDDLEWARE = [
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'mozilla_django_oidc.middleware.SessionRefresh',  # make sure User's ID token is still valid
+    'hermes.middleware.SCiMMAAuthSessionRefresh',  # refresh SCiMMA Auth API tokens if necessary
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]


### PR DESCRIPTION
This PR maintains the SCiMMA Auth API tokens for both the Hermes service account and the currently logged in user in middlewar.py::SCiMMAAuthSessionRefresh.  The api tokens are stored in the request.session SessionStore and examined as requests pass through the middleware.   It's weird to me that every request pays this overhead but I don't know of another way.

This is a draft request because there's still a lot of clean up to do in the SCiMMA Auth API client, hopskotch.py