### PR TITLE
Fixes/pagination and validation

### DIFF
--- a/hermes/serializers.py
+++ b/hermes/serializers.py
@@ -1,6 +1,6 @@
 from hermes.models import Message, NonLocalizedEvent, NonLocalizedEventSequence, Target
 from rest_framework import serializers
-from astropy.coordinates import Angle, SkyCoord
+from astropy.coordinates import Longitude, Latitude
 from astropy import units
 from dateutil.parser import parse
 from datetime import datetime
@@ -34,12 +34,12 @@ class BaseTargetSerializer(serializers.ModelSerializer):
 
     def get_right_ascension_sexagesimal(self, obj):
         if obj.coordinate:
-            a = Angle(obj.coordinate.x, unit=units.degree)
+            a = Longitude(obj.coordinate.x, unit=units.degree)
             return a.to_string(unit=units.hour, sep=':')
 
     def get_declination_sexagesimal(self, obj):
         if obj.coordinate:
-            a = Angle(obj.coordinate.y, unit=units.degree)
+            a = Latitude(obj.coordinate.y, unit=units.degree)
             return a.to_string(unit=units.degree, sep=':')
 
 
@@ -161,13 +161,13 @@ class CandidateSerializer(serializers.Serializer):
     def validate_ra(self, value):
         try:
             float_ra = float(value)
-            ra_angle = Angle(float_ra * units.deg)
+            ra_angle = Longitude(float_ra * units.deg)
         except:
             try:
-                ra_angle = Angle(value, unit=units.hourangle)
+                ra_angle = Longitude(value, unit=units.hourangle)
             except:
                 try:
-                    ra_angle = Angle(value)
+                    ra_angle = Longitude(value)
                 except:
                     raise serializers.ValidationError(_("Must be in a format astropy understands"))
         return ra_angle.deg
@@ -175,13 +175,13 @@ class CandidateSerializer(serializers.Serializer):
     def validate_dec(self, value):
         try:
             float_dec = float(value)
-            dec_angle = Angle(float_dec * units.deg)
+            dec_angle = Latitude(float_dec * units.deg)
         except:
             try:
-                dec_angle = Angle(value, unit=units.hourangle)
+                dec_angle = Latitude(value, unit=units.hourangle)
             except:
                 try:
-                    dec_angle = Angle(value)
+                    dec_angle = Latitude(value)
                 except:
                     raise serializers.ValidationError(_("Must be in a format astropy understands"))
         return dec_angle.deg
@@ -224,13 +224,13 @@ class PhotometrySerializer(serializers.Serializer):
     def validate_ra(self, value):
         try:
             float_ra = float(value)
-            ra_angle = Angle(float_ra * units.deg)
+            ra_angle = Longitude(float_ra * units.deg)
         except:
             try:
-                ra_angle = Angle(value, unit=units.hourangle)
+                ra_angle = Longitude(value, unit=units.hourangle)
             except:
                 try:
-                    ra_angle = Angle(value)
+                    ra_angle = Longitude(value)
                 except:
                     raise serializers.ValidationError(_("Must be in a format astropy understands"))
         return ra_angle.deg
@@ -238,13 +238,13 @@ class PhotometrySerializer(serializers.Serializer):
     def validate_dec(self, value):
         try:
             float_dec = float(value)
-            dec_angle = Angle(float_dec * units.deg)
+            dec_angle = Latitude(float_dec * units.deg)
         except:
             try:
-                dec_angle = Angle(value, unit=units.hourangle)
+                dec_angle = Latitude(value, unit=units.hourangle)
             except:
                 try:
-                    dec_angle = Angle(value)
+                    dec_angle = Latitude(value)
                 except:
                     raise serializers.ValidationError(_("Must be in a format astropy understands"))
         return dec_angle.deg

--- a/hermes/utils.py
+++ b/hermes/utils.py
@@ -5,6 +5,6 @@ from hermes.models import Message
 def get_all_public_topics():
     all_topics = cache.get("all_public_topics", None)
     if not all_topics:
-        all_topics = list(Message.objects.order_by().values_list('topic', flat=True).distinct())
+        all_topics = sorted(list(Message.objects.order_by().values_list('topic', flat=True).distinct()))
         cache.set("all_public_topics", all_topics, 3600)
     return all_topics

--- a/hermes_base/settings.py
+++ b/hermes_base/settings.py
@@ -215,7 +215,7 @@ SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
 REST_FRAMEWORK = {
     'DEFAULT_METADATA_CLASS': 'rest_framework.metadata.SimpleMetadata',
-    "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
+    "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.LimitOffsetPagination",
     "PAGE_SIZE": 100,
 }
 
@@ -231,7 +231,6 @@ ALERT_STREAMS = [
             'PASSWORD': os.getenv('SCIMMA_AUTH_PASSWORD', ''),
             'TOPIC_HANDLERS': {
                 'hermes.test': 'hermes.alertstream_handlers.ingest_from_hop.handle_hermes_message',
-                'hermes-perm.test': 'hermes.alertstream_handlers.ingest_from_hop.handle_hermes_message',
                 'gcn.circular': 'hermes.alertstream_handlers.ingest_from_hop.handle_gcn_circular_message',
                 #'*': 'hermes.alertstream_handlers.ingest_from_hop.handle_generic_message',
             },
@@ -247,8 +246,8 @@ ALERT_STREAMS = [
             'GCN_CLASSIC_CLIENT_SECRET': os.getenv('GCN_CLASSIC_CLIENT_SECRET', ''),
             'DOMAIN': 'gcn.nasa.gov',  # optional, defaults to 'gcn.nasa.gov'
             'CONFIG': {  # optional
-                # 'group.id': 'tom_alertstreams-my-custom-group-id',
-                'auto.offset.reset': 'earliest',
+                'group.id': os.getenv('GCN_CLASSIC_OVER_KAFKA_GROUP_ID', 'hermes-dev'),
+                # 'auto.offset.reset': 'earliest',
                 # 'enable.auto.commit': False
             },
             'TOPIC_HANDLERS': {
@@ -283,6 +282,13 @@ CORS_ALLOW_HEADERS = list(default_headers) + [
 # https://docs.djangoproject.com/en/4.0/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+CACHES = {
+     'default': {
+         'BACKEND': os.getenv('CACHE_BACKEND', 'django.core.cache.backends.locmem.LocMemCache'),
+         'LOCATION': os.getenv('CACHE_LOCATION', 'default-cache')
+     }
+}
 
 #
 # Logging


### PR DESCRIPTION
Some various backend fixes, including setting limitoffsetpagination, and fixing RA/DEC validation to use astropys Longitude and Latitude instead of Angle. @jchate6 This does the check for -90 to 90 for dec, but RA can still be any value and it just is converted to a value between 0 and 360. Astropy also supports any value for RA for SkyCoord, and its just a circle anyway, so I think this is okay, but let me know if its not.