### PR TITLE
Feature/reduce login time

### DIFF
--- a/hermes/auth_backends.py
+++ b/hermes/auth_backends.py
@@ -11,7 +11,7 @@ from hermes.brokers import hopskotch
 from hermes.models import Profile
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
+#logger.setLevel(logging.DEBUG)
 
 class NotInKafkaUsers(PermissionDenied):
     """COManage maintains a kafkaUsers group that a User must

--- a/hermes/auth_backends.py
+++ b/hermes/auth_backends.py
@@ -168,9 +168,9 @@ class HopskotchOIDCAuthenticationBackend(auth.OIDCAuthenticationBackend):
         # make sure the User exists in SCiMMA Auth
         scimma_auth_user, created = hopskotch.get_or_create_user(claims)
         if created:
-            logger.info(f'create_user - Created SCiMMA Auth User {scimma_auth_user}')
+            logger.info(f'update_user - Created SCiMMA Auth User {scimma_auth_user}')
         else:
-            logger.info(f'create_user - Found existing SCiMMA Auth User {scimma_auth_user}')
+            logger.info(f'update_user - Found existing SCiMMA Auth User {scimma_auth_user}')
 
         # NOTE: if we ever wanted to save the claims in the session, this (and create_user) would
         #   be the place to do it.

--- a/hermes/brokers/hopskotch.py
+++ b/hermes/brokers/hopskotch.py
@@ -457,17 +457,19 @@ def get_user_hop_authorization(hop_user: dict, user_api_token) -> Auth:
     username = hop_user['username']
 
     # Construct URL to create Hop Auth SCRAM credentials for this user
-    user_credentials_url = get_hop_auth_api_url() + f'/users/{hop_user_pk}/credentials'
+    url = get_hop_auth_api_url() + f'/users/{hop_user_pk}/credentials'
 
     logger.info(f'get_user_hop_authorization Creating SCRAM credentials for user {username}')
-    user_credentials_response = requests.post(user_credentials_url,
+    response = requests.post(url,
                                               data=json.dumps({'description': 'Created by HERMES'}),
                                               headers={'Authorization': user_api_token,
                                                        'Content-Type': 'application/json'})
-    logger.debug(f'get_user_hop_authroization user_credentials_response.json(): {user_credentials_response.json()}')
+    # for example, {'username': 'llindstrom-93fee00b', 'password': 'asdlkjfsadkjf'}
+    logger.debug(f'get_user_hop_authorization user_credentials_response.json(): {response.json()}')
 
-    user_hop_username = user_credentials_response.json()['username']
-    user_hop_password = user_credentials_response.json()['password']
+    # TODO: extract and return credential_pk from response when available (ChrisW working on it)
+    user_hop_username = response.json()['username']
+    user_hop_password = response.json()['password']
 
     # you can never again get this SCRAM credential, so save it somewhere (like the Session)
     user_hop_authorization: Auth = Auth(user_hop_username, user_hop_password)

--- a/hermes/brokers/hopskotch.py
+++ b/hermes/brokers/hopskotch.py
@@ -233,7 +233,7 @@ def authorize_user(username: str, hermes_api_token: str) -> Auth:
         logger.info(f'authorize_user User {username} already a member of group {group_name}')
 
     # create user SCRAM credential (hop.auth.Auth instance)
-    user_hop_auth: Auth = get_user_hop_authorization(username, user_api_token)
+    user_hop_auth: Auth = get_user_hop_authorization(hop_user, user_api_token)
     logger.info(f'authorize_user SCRAM credential created for {username}:  {user_hop_auth.username}')
     credential_pk = _get_hop_credential_pk(username, user_hop_auth.username, user_api_token=user_api_token, user_pk=user_pk)
 
@@ -427,11 +427,14 @@ def _get_hop_credential_pk(username, credential_name, user_api_token: str, user_
 
 
 
-def get_user_hop_authorization(username, user_api_token) -> Auth:
+def get_user_hop_authorization(hop_user: dict, user_api_token) -> Auth:
     """Return the hop.auth.Auth instance for the user with the given username.
     """
+    # extract values from hop_user dict
+    hop_user_pk = hop_user['pk']
+    username = hop_user['username']
+
     # Construct URL to create Hop Auth SCRAM credentials for this user
-    hop_user_pk = _get_hop_user_pk(username, user_api_token)  # need the pk for the URL
     user_credentials_url = get_hop_auth_api_url() + f'/users/{hop_user_pk}/credentials'
 
     logger.info(f'get_user_hop_authorization Creating SCRAM credentials for user {username}')

--- a/hermes/brokers/hopskotch.py
+++ b/hermes/brokers/hopskotch.py
@@ -89,22 +89,22 @@ def _get_hermes_api_token(scram_username, scram_password) -> str:
     # Peform the first round of the SCRAM handshake:
     client = scramp.ScramClient(["SCRAM-SHA-512"], scram_username, scram_password)
     client_first = client.get_client_first()
-    logger.debug(f'SCRAM client first request: {client_first}')
+    logger.debug(f'_get_hermes_api_token: SCRAM client first request: {client_first}')
 
     scram_resp1 = requests.post(hop_auth_api_url + '/scram/first',
                                 json={"client_first": client_first},
                                 headers={"Content-Type":"application/json"})
-    logger.debug(f'SCRAM server first response: {scram_resp1.json()}')
+    logger.debug(f'_get_hermes_api_token: SCRAM server first response: {scram_resp1.json()}')
 
     # Peform the second round of the SCRAM handshake:
     client.set_server_first(scram_resp1.json()["server_first"])
     client_final = client.get_client_final()
-    logger.debug(f'SCRAM client final request: {client_final}')
+    logger.debug(f'_get_hermes_api_token: SCRAM client final request: {client_final}')
 
     scram_resp2 = requests.post(hop_auth_api_url + '/scram/final',
                                 json={"client_final": client_final},
                                 headers={"Content-Type":"application/json"})
-    logger.debug(f'SCRAM server final response: {scram_resp2.json()}')
+    logger.debug(f'_get_hermes_api_token: SCRAM server final response: {scram_resp2.json()}')
 
     client.set_server_final(scram_resp2.json()["server_final"])
 
@@ -113,7 +113,7 @@ def _get_hermes_api_token(scram_username, scram_password) -> str:
     hermes_api_token = response_json["token"]
     hermes_api_token_expiration = response_json['token_expires']
     hermes_api_token = f'Token {hermes_api_token}'  # Django wants this (Token<space>) prefix
-    logger.debug(f'get_hermes_api_token: Token issued: {hermes_api_token} expiration: {hermes_api_token_expiration}')
+    logger.debug(f'_get_hermes_api_token: Token issued: {hermes_api_token} expiration: {hermes_api_token_expiration}')
 
     return hermes_api_token, hermes_api_token_expiration
 

--- a/hermes/brokers/hopskotch.py
+++ b/hermes/brokers/hopskotch.py
@@ -425,7 +425,7 @@ def _get_hop_credential_pk(username, credential_name, user_api_token: str, user_
         user_pk = _get_hop_user_pk(username, user_api_token)
 
     # get the list of credentials for the user
-    hop_credentials = get_user_hop_credentials(username, user_api_token)
+    hop_credentials = get_user_hop_credentials(user_pk, user_api_token)
 
     # extract the one that matches the Auth user.username
     # this is the idiom for searchng a list of dictionaries for certain key-value (topic_name)
@@ -471,7 +471,7 @@ def get_user_hop_authorization(hop_user: dict, user_api_token) -> Auth:
     return user_hop_authorization
 
 
-def get_user_hop_credentials(username, user_api_token):
+def get_user_hop_credentials(user_pk, user_api_token):
     """return a list of credential dictionaries for the user with the given username
 
     The dictionaries look like this:
@@ -490,10 +490,9 @@ def get_user_hop_credentials(username, user_api_token):
       * the username key in the returned credential dict is the SCRAM credential name
 
     """
-    hop_user_pk = _get_hop_user_pk(username, user_api_token)  # need the pk for the URL
 
-    # limit the API query to the specific users (whose pk we just found)
-    url = get_hop_auth_api_url() + f'/users/{hop_user_pk}/credentials'
+    # limit the API query to the specific user
+    url = get_hop_auth_api_url() + f'/users/{user_pk}/credentials'
 
     response = requests.get(url,
                             headers={'Authorization': user_api_token,

--- a/hermes/brokers/hopskotch.py
+++ b/hermes/brokers/hopskotch.py
@@ -253,6 +253,8 @@ def add_permissions_to_credential(user_pk, credential_pk, user_api_token, hermes
 
     for group_pk in user_group_pks:
         for group_permission in get_group_permissions_received(group_pk, user_api_token):
+            logger.info((f'add_permissions_to_credential Adding {group_permission["operation"]} permission to '
+                         f'topic {group_permission["topic"]} for user(cred): {user_pk}({credential_pk})'))
             _add_permission_to_credential_for_user(user_pk, credential_pk, group_permission['topic'],
                                                    group_permission['operation'], user_api_token)
 
@@ -764,13 +766,13 @@ def _add_permission_to_credential_for_user(user_pk: int, credential_pk: int, top
     if response.status_code == 500:
         logger.error((f'_add_permission_to_credential_for_user ({response.status_code}) Failed to add {operation} '
                       f'permission to topic {_get_hop_topic_from_pk(topic_pk, api_token)}'))
-        logger.error(f'_add_permission_to_credential_for_user response.text {response.text}')
+        logger.debug(f'_add_permission_to_credential_for_user response.text {response.text}')
     elif response.status_code == 200 or response.status_code == 201:
         logger.debug((f'_add_permission_to_credential_for_user ({response.status_code}) Added {operation} '
-                      f'permission to topic {_get_hop_topic_from_pk(topic_pk, api_token)}'))
+                      f'permission to {request_data}'))
     else:
-        logger.debug((f'_add_permission_to_credential_for_user ({response.status_code}) Attempted {operation} '
-                      f'permission to topic {_get_hop_topic_from_pk(topic_pk, api_token)}'))
+        logger.warning((f'_add_permission_to_credential_for_user ({response.status_code}) 201 expected for {operation} '
+                        f'permission to {request_data}'))
 
 
 def get_user_writable_topics(username, credential_name, user_api_token, exclude_groups=None):

--- a/hermes/brokers/hopskotch.py
+++ b/hermes/brokers/hopskotch.py
@@ -45,11 +45,13 @@ import scramp
 ##     logger.debug(f'in {currentFuncName()} called by {currentFuncName(1)}')
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
+#logger.setLevel(logging.DEBUG)
 
-# TODO: the idea is that SCIMMA_ADMIN_BASE_URL is the only configuration
-#   needed in settings.py, but consider moving the service account creds
-#   there as well
+#  The idea is that SCIMMA_ADMIN_BASE_URL is the only configuration
+#  needed in settings.py
+#  That's why the Hermes Service Account SCiMMA Auth SCRAM Cred is
+#  read from the envirionment here. (It might be confusing that they're
+#  not in settings.py
 
 #  from the environment, get the HERMES service account credentials for SCiMMA Auth (scimma-admin).
 HERMES_USERNAME = os.getenv('HERMES_USERNAME', None)
@@ -234,6 +236,8 @@ def add_permissions_to_credential(user_pk, credential_pk, user_api_token, hermes
 
     This method determines the applicable Topics ('pk' and 'operation') and hands off the work to
     _add_permission_to_credential_for_user().
+
+    This method also adds the User to the hermes group if not already a Member.
     """
     user_groups = get_user_groups(user_pk, user_api_token)
     user_group_pks = [group['pk'] for group in user_groups]
@@ -245,8 +249,7 @@ def add_permissions_to_credential(user_pk, credential_pk, user_api_token, hermes
         hermes_group_pk = _get_hop_group_pk(hermes_group_name, user_api_token=user_api_token)
         add_user_to_group(user_pk, hermes_group_pk, hermes_api_token)
     else:
-        logger.info(f'add_permissions_to_credentials User (pk={user_pk}) already a member of group {hermes_group_name}')
-
+        logger.info(f'add_permissions_to_credential User (pk={user_pk}) already a member of group {hermes_group_name}')
 
     for group_pk in user_group_pks:
         for group_permission in get_group_permissions_received(group_pk, user_api_token):

--- a/hermes/brokers/hopskotch.py
+++ b/hermes/brokers/hopskotch.py
@@ -35,6 +35,14 @@ from rest_framework.response import Response
 
 import scramp
 
+## # this is a (printf-)debugging utility:
+## import sys
+## # for current func name, specify 0 or no argument.
+## # for name of caller of current func, specify 1.
+## # for name of caller of caller of current func, specify 2. etc.
+## currentFuncName = lambda n=0: sys._getframe(n + 1).f_code.co_name
+## # then, after a function def:
+##     logger.debug(f'in {currentFuncName()} called by {currentFuncName(1)}')
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
@@ -160,7 +168,7 @@ def get_or_create_user(claims: dict):
         "email": "llindstrom@lco.global"
     }
     """
-    logger.info(f'get_or_create_user claims: {claims}')
+    logger.debug(f'get_or_create_user claims: {claims}')
 
     # check to see if the user already exists in SCiMMA Auth
     hermes_api_token, _ = get_hermes_api_token()
@@ -227,8 +235,6 @@ def add_permissions_to_credential(user_pk, credential_pk, user_api_token, hermes
     This method determines the applicable Topics ('pk' and 'operation') and hands off the work to
     _add_permission_to_credential_for_user().
     """
-    logger.debug(f'in {currentFuncName()} called by {currentFuncName(1)}')
-
     user_groups = get_user_groups(user_pk, user_api_token)
     user_group_pks = [group['pk'] for group in user_groups]
 
@@ -490,7 +496,6 @@ def get_user_hop_credentials(user_pk, user_api_token):
       * the username key in the returned credential dict is the SCRAM credential name
 
     """
-
     # limit the API query to the specific user
     url = get_hop_auth_api_url() + f'/users/{user_pk}/credentials'
 
@@ -694,7 +699,6 @@ def get_group_permissions_received(group_pk, user_api_token):
     }
     """
     url = get_hop_auth_api_url() + f'/groups/{group_pk}/permissions_received'
-    logger.debug(f'get_group_permissions_recieved url: {url}')
     response =  requests.get(url,
                              headers={'Authorization': user_api_token,
                                       'Content-Type': 'application/json'})

--- a/hermes/brokers/hopskotch.py
+++ b/hermes/brokers/hopskotch.py
@@ -253,10 +253,6 @@ def add_permissions_to_credential(user_pk, credential_pk, user_api_token, hermes
             _add_permission_to_credential_for_user(user_pk, credential_pk, group_permission['topic'],
                                                    group_permission['operation'], user_api_token)
 
-    # This is just to check what topic permissions are reported back to the UI (just for testing)
-    logger.debug(f'add_permissions_to_credential: {_get_user_topic_permissions(user_pk, credential_pk, user_api_token )}')
-
-
 def deauthorize_user(username: str, user_hop_auth: Auth, user_api_token):
     """Remove from Hop Auth the SCRAM credentials (user_hop_auth) that were created
     for this session.

--- a/hermes/middleware.py
+++ b/hermes/middleware.py
@@ -36,7 +36,7 @@ class SCiMMAAuthSessionRefresh:
         We might need to refresh the Hermes service account SCiMMA Auth API token along the way,
         since admin privilidges are required to get the User API token
         """
-        logger.debug(f'Refreshing SCiMMA Auth API token for User.')
+        logger.debug(f'Refreshing SCiMMA Auth API token for User {request.user} ({request.user.username})')
 
         # get the hermes service account API token and check it's expiration status
         hermes_api_token_expiration_str: str = request.session.get('hermes_api_token_expiration', None)
@@ -52,11 +52,13 @@ class SCiMMAAuthSessionRefresh:
         else:
             logger.debug(f'SCiMMA Auth API token for Hermes service account up-to-date.')
         
-        username = request.user.username
-        hermes_api_token = request.session['hermes_api_token']
-        user_api_token, user_api_token_expiration = hopskotch.get_user_api_token(username, hermes_api_token)
-        request.session['user_api_token'] = user_api_token
-        request.session['user_api_token_expiration'] = user_api_token_expiration
+        if request.user.username:
+            hermes_api_token = request.session['hermes_api_token']
+            user_api_token, user_api_token_expiration = hopskotch.get_user_api_token(request.user.username, hermes_api_token)
+            request.session['user_api_token'] = user_api_token
+            request.session['user_api_token_expiration'] = user_api_token_expiration
+        else:
+            logger.debug(f'SCiMMA Auth API token for {request.user} not applicable (no-op).')    
 
 
     def __call__(self, request):


### PR DESCRIPTION
Various optimization for reducing the number SCiMMA Auth API requests during login.
I've conferred with Chris W and we are using the API correctly.

One optimization we've agreed upon in returning the SCRAM cred PK from a POST to `/users/<PK>/credentials` which will save one API request. Any further saving must come from the server to reduce requests as we query and apply topic permissions to SCRAM creds.