### PR TITLE
Changed the login/refresh stuff to work more reliably. Added redis to…

### DIFF
--- a/helm-chart/requirements.lock
+++ b/helm-chart/requirements.lock
@@ -2,5 +2,8 @@ dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
   version: 11.9.13
-digest: sha256:cc58f23196c1cec7ca16bc611f01e75755d6ec2ba88a91a87128dbad7bfa1737
-generated: "2023-01-06T22:00:58.710274109Z"
+- name: redis
+  repository: https://helm.lco.global
+  version: 10.6.13
+digest: sha256:7cbe7657d82c5681472c3a672c37e5c3e25d0e6188c72615852ff5f345e8306f
+generated: "2023-04-03T18:31:07.581940675-04:00"

--- a/helm-chart/requirements.yaml
+++ b/helm-chart/requirements.yaml
@@ -3,3 +3,7 @@ dependencies:
   version: 11.9.13
   repository: https://charts.bitnami.com/bitnami
   condition: useDockerizedDatabase
+- name: redis
+  version: 10.6.13
+  repository: https://helm.lco.global
+  condition: redis.enabled

--- a/helm-chart/templates/_helpers.tpl
+++ b/helm-chart/templates/_helpers.tpl
@@ -83,6 +83,19 @@ Generate the postgres DB hostname
 {{- end -}}
 
 {{/*
+Generate the cache location
+*/}}
+{{- define "hermes.cacheLocation" -}}
+{{- if not .Values.redis.enabled -}}
+{{- required "Must set `redisURL`" .Values.redisURL -}}
+{{- else if .Values.redis.fullnameOverride -}}
+{{- printf "redis://%s-master:%s/0" .Values.redis.fullnameOverride .Values.redis.master.port -}}
+{{- else -}}
+{{- printf "redis://%s-redis-master:%s/0" .Release.Name .Values.redis.master.port -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create the environment variables for configuration of this project. They are
 repeated in a bunch of places, so to keep from repeating ourselves, we'll
 build it here and use it everywhere.
@@ -92,6 +105,10 @@ build it here and use it everywhere.
   value: "/tmp"
 - name: DEBUG
   value: {{ .Values.djangoDebug | toString | lower | title | quote }}
+- name CACHE_BACKEND
+  value: {{ .Values.cacheBackend | quote }}
+- name: CACHE_LOCATION
+  value: {{ include "hermes.cacheLocation" . | quote }}
 - name: HERMES_FRONT_END_BASE_URL
   value: {{ .Values.hermesFrontEndBaseUrl | quote }}
 - name: HOP_AUTH_BASE_URL

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -79,6 +79,7 @@ resources: {}
 # Settings for the PostgreSQL database
 applyDatabaseMigrations: true
 useDockerizedDatabase: true
+cacheBackend: "django.core.cache.backends.redis.RedisCache"
 
 djangoDatabaseEngine: "django.db.backends.postgresql"
 postgresql:
@@ -106,6 +107,31 @@ postgresql:
 
 secretKey: "changeme"
 
+redis:
+  # If enabled, an in-cluster Redis instance will be spun up.
+  # Otherwise, redisURL will be used.
+  enabled: true
+  usePassword: false
+  master:
+    port: "6379"
+    disableCommands: ["FLUSHALL"]
+    persistence:
+      enabled: true
+      size: 256Mi
+    resources:
+      requests:
+        cpu: 50m
+        memory: 128Mi
+      limits:
+        cpu: 250m
+        memory: 512Mi
+  cluster:
+    enabled: false
+  configmap: |-
+    maxmemory 256mb
+    maxmemory-policy volatile-lru
+    # idle client timeout after 600 seconds
+    timeout 600
 
 loadInitialData:
   enabled: false

--- a/hermes/auth_backends.py
+++ b/hermes/auth_backends.py
@@ -200,7 +200,7 @@ class HopskotchOIDCAuthenticationBackend(auth.OIDCAuthenticationBackend):
         """
         user = super().authenticate(request, **kwargs) # django.contrib.auth.models.User
 
-        hermes_api_token = request.session['hermes_api_token']
+        hermes_api_token = hopskotch.get_hermes_api_token()
         hop_auth = hopskotch.authorize_user(user.get_username(), hermes_api_token)
 
         # Auth instances are not trivially serializable with json.dumps. So use jsons.dump:

--- a/hermes/middleware.py
+++ b/hermes/middleware.py
@@ -2,8 +2,12 @@ import logging
 import datetime
 
 from django.utils import dateparse
+from django.contrib.auth import logout
+from django.http import HttpResponse
 
 from hermes.brokers import hopskotch
+from hermes.auth_backends import hopskotch_logout
+
 
 logger = logging.getLogger(__name__)
 #logger.setLevel(logging.DEBUG)
@@ -22,14 +26,6 @@ class SCiMMAAuthSessionRefresh:
         some_mintues_from_now = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(minutes=15)
         return some_mintues_from_now > expiration # > means True if expiration is in past
 
-
-    def refresh_hermes_token(self, request):
-        logger.debug(f'Refreshing SCiMMA Auth API token for Hermes service account.')
-        hermes_api_token, hermes_api_token_expiration = hopskotch.get_hermes_api_token()
-        request.session['hermes_api_token'] = hermes_api_token
-        request.session['hermes_api_token_expiration'] = hermes_api_token_expiration
-
-
     def refresh_user_token(self, request):
         """Refresh the SCiMMA Auth User API token in the request.session.
 
@@ -37,28 +33,10 @@ class SCiMMAAuthSessionRefresh:
         since admin privilidges are required to get the User API token
         """
         logger.debug(f'Refreshing SCiMMA Auth API token for User {request.user} ({request.user.username})')
-
-        # get the hermes service account API token and check it's expiration status
-        hermes_api_token_expiration_str: str = request.session.get('hermes_api_token_expiration', None)
-        if hermes_api_token_expiration_str:
-            hermes_api_token_expiration: datetime.datetime = dateparse.parse_datetime(hermes_api_token_expiration_str)
-            need_new_hermes_api_token = self._is_expired(hermes_api_token_expiration)
-        else:
-            need_new_hermes_api_token = True
-        
-        if need_new_hermes_api_token:
-            logger.debug(f'New SCiMMA Auth API token for Hermes service account needed.')
-            self.refresh_hermes_token(request)
-        else:
-            logger.debug(f'SCiMMA Auth API token for Hermes service account up-to-date.')
-        
-        if request.user.username:
-            hermes_api_token = request.session['hermes_api_token']
-            user_api_token, user_api_token_expiration = hopskotch.get_user_api_token(request.user.username, hermes_api_token)
-            request.session['user_api_token'] = user_api_token
-            request.session['user_api_token_expiration'] = user_api_token_expiration
-        else:
-            logger.debug(f'SCiMMA Auth API token for {request.user} not applicable (no-op).')    
+        hermes_api_token = hopskotch.get_hermes_api_token()
+        user_api_token, user_api_token_expiration = hopskotch.get_user_api_token(request.user.username, hermes_api_token)
+        request.session['user_api_token'] = user_api_token
+        request.session['user_api_token_expiration'] = user_api_token_expiration
 
 
     def __call__(self, request):
@@ -66,26 +44,35 @@ class SCiMMAAuthSessionRefresh:
         # the view (and later middleware) are called.
         logger.debug(f'maintaining SCiMMA Auth API tokens in Session...')
 
+        # First check the oidc token expiration - if expired, return a HTTP 401 to indicate client should logout
+        oidc_expiration_seconds = request.session.get('oidc_id_token_expiration')
+        if oidc_expiration_seconds:
+            if datetime.datetime.utcnow() > datetime.datetime.fromtimestamp(float(oidc_expiration_seconds)):
+                logger.debug(f"OIDC login has expired for user {request.user}, forcing hop logout and returning 401")
+                hopskotch_logout(request)
+                logout(request)
+                return HttpResponse('Unauthorized', status=401)
+
         # IMPORTANT: we only check the user api token here, but that might trigger a hermes_api_token
         # get/refresh, and we need that to authenticate users in auth_backends.
-
-        user_api_token_expiration_str: str = request.session.get('user_api_token_expiration', None)
-        if user_api_token_expiration_str:
-            user_api_token_expiration: datetime.datetime = dateparse.parse_datetime(user_api_token_expiration_str)
-            need_new_user_api_token = self._is_expired(user_api_token_expiration)
+        if request.user.username:
+            user_api_token_expiration_str: str = request.session.get('user_api_token_expiration', None)
+            if user_api_token_expiration_str:
+                user_api_token_expiration: datetime.datetime = dateparse.parse_datetime(user_api_token_expiration_str)
+                need_new_user_api_token = self._is_expired(user_api_token_expiration)
+            else:
+                need_new_user_api_token = True
+            if need_new_user_api_token:
+                logger.debug(f'New SCiMMA Auth API user token needed for {request.user} ({request.user.username})')
+                self.refresh_user_token(request)
+            else:
+                # the api_token is either not expired or non-existent (for the AnonymousUser)
+                logger.debug(f'SCiMMA Auth API token for {request.user} ({request.user.username}): refresh not needed.')
         else:
-            need_new_user_api_token = True  # even if it's the AnonmymousUser, to trigger hermes_api_token get/refresh
-        
-        if need_new_user_api_token:
-            logger.debug(f'New SCiMMA Auth API user token needed for {request.user} ({request.user.username})')
-            self.refresh_user_token(request)
-        else:
-            # the api_token is either not expired or non-existent (for the AnonymousUser)
-            logger.debug(f'SCiMMA Auth API token for {request.user} ({request.user.username}): refresh not needed.')
+            logger.debug(f'No user is logged in, so not refreshing user token.')
 
         response = self.get_response(request)  # pass the request to the next Middleware in the list
 
         # Code to be executed for each request/response after
         # the view is called.
-
         return response

--- a/hermes_base/settings.py
+++ b/hermes_base/settings.py
@@ -34,7 +34,6 @@ DEBUG = True
 
 ALLOWED_HOSTS = ['*']
 
-
 # Application definition
 
 INSTALLED_APPS = [
@@ -62,7 +61,6 @@ MIDDLEWARE = [
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'mozilla_django_oidc.middleware.SessionRefresh',  # make sure User's ID token is still valid
     'hermes.middleware.SCiMMAAuthSessionRefresh',  # refresh SCiMMA Auth API tokens if necessary
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
@@ -174,6 +172,9 @@ OIDC_OP_JWKS_ENDPOINT = 'https://login.scimma.org/realms/SCiMMA/protocol/openid-
 # this method is invoke upon /logout -> mozilla_django_oidc.ODICLogoutView.post
 OIDC_OP_LOGOUT_URL_METHOD = 'hermes.auth_backends.hopskotch_logout'
 
+# Set the OIDC login to be valid for 2 weeks since we disabled the refresh middleware
+OIDC_RENEW_ID_TOKEN_EXPIRY_SECONDS = 60 * 60 * 24 * 14
+
 # this tells mozilla-django-oidc that the front end can logout with a GET
 # which allows the front end to use location.href to /auth/logout to logout.
 ALLOW_LOGOUT_GET_METHOD = True
@@ -259,11 +260,11 @@ ALERT_STREAMS = [
                 # 'gcn.classic.text.SWIFT_POINTDIR': 'tom_demo.log_stuff.handle_message',
                 # 'gcn.classic.text.LVC_INITIAL': 'tom_demo.log_stuff.handle_message',
                 'gcn.classic.text.LVC_INITIAL': 'hermes.alertstream_handlers.ingest_from_gcn_classic.handle_message',
-                'gcn.classic.text.LVC_COUNTERPART': 'hermes.alertstream_handlers.ingest_from_gcn_classic.handle_message',
+                #'gcn.classic.text.LVC_COUNTERPART': 'hermes.alertstream_handlers.ingest_from_gcn_classic.handle_message',
                 'gcn.classic.text.LVC_PRELIMINARY': 'hermes.alertstream_handlers.ingest_from_gcn_classic.handle_message',
                 'gcn.classic.text.LVC_RETRACTION': 'hermes.alertstream_handlers.ingest_from_gcn_classic.handle_message',
-                'gcn.classic.text.LVC_TEST': 'hermes.alertstream_handlers.ingest_from_gcn_classic.handle_message',
-                'gcn.classic.text.LVC_UPDATE': 'hermes.alertstream_handlers.ingest_from_gcn_classic.handle_message',
+                #'gcn.classic.text.LVC_TEST': 'hermes.alertstream_handlers.ingest_from_gcn_classic.handle_message',
+                #'gcn.classic.text.LVC_UPDATE': 'hermes.alertstream_handlers.ingest_from_gcn_classic.handle_message',
             },
         },
     }

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ numpy~=1.24.0
 Django>=4
 djangorestframework==3.13.1
 django-filter>=2.4
+redis>=3
 psycopg2-binary==2.9.3
 django-bootstrap4==22.1
 fastavro>=1.7


### PR DESCRIPTION
… deployment

The main things here are I removed the mozilla middleware, since that tried to redirect API calls which really doesn't work. Instead, I am checking the oidc expiration cookie in our middleware and if it has expired, triggering a logout of hop and returning a HTTP 401 UNAUTHORIZED, which the front end will have to check for on all API calls and then trigger a "logout". Then I am setting the oidc expiration time to 2 weeks out.

I am also adding a redis container to the deployment, and setting up the cache to use redis. This is because I am storing the hop admin account credentials in redis rather than the session cookie for each user, and just re-computing it if it expires from the cache. I haven't tested this part yet but I was planning to do it in dev :).