### PR TITLE
add HOPSKOTCH_GROUP_ID env var assigned in values*.yaml

### DIFF
--- a/helm-chart/templates/_helpers.tpl
+++ b/helm-chart/templates/_helpers.tpl
@@ -98,6 +98,8 @@ build it here and use it everywhere.
   value: {{ .Values.hopAuthBaseUrl | quote }}
 - name: GCN_CLASSIC_OVER_KAFKA_GROUP_ID
   value: {{ .Values.brokers.gcnClassicOverKafka.groupId | quote }}
+- name: HOPSKOTCH_GROUP_ID
+  value: {{ .Values.brokers.hopskotch.groupId | quote }}
 {{- end }}
 
 {{/*

--- a/helm-chart/values-dev.yaml
+++ b/helm-chart/values-dev.yaml
@@ -13,6 +13,8 @@ resources:
 brokers:
   gcnClassicOverKafka:
     groupId: 'hermes-dev'
+  hopskotch:
+    groupId: 'hermes-dev'
 
 hermesFrontEndBaseUrl: http://hermes-dev.lco.gtn/
 

--- a/helm-chart/values-prod.yaml
+++ b/helm-chart/values-prod.yaml
@@ -15,6 +15,8 @@ resources:
 brokers:
   gcnClassicOverKafka:
     groupId: 'hermes'
+  hopskotch:
+    groupId: 'hermes'
 
 hermesFrontEndBaseUrl: https://hermes.lco.global/
 

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -26,6 +26,8 @@ fullnameOverride: ""
 brokers:
   gcnClassicOverKafka:
     groupId: 'hermes-dev'
+  hopskotch:
+    groupId: 'hermes-dev'
 
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
Jon, I'm not sure how we've been deploying to `hermes-rc1`. If that's been happening manually (i.e. not through helmPipeline() then I think we need to set the`brokers.hopskotch.groupId` value on the command line for an `rc1` deploy. Is that right?