### PR TITLE
Add hearbeat api endpoint to get timestamps of last stream activity

### DIFF
--- a/hermes/views.py
+++ b/hermes/views.py
@@ -8,7 +8,7 @@ from django.conf import settings
 #from django.views.decorators.csrf import csrf_exempt
 from django.http import JsonResponse
 from django.middleware import csrf
-
+from django.core.cache import cache
 from django.views.generic import ListView, DetailView, FormView, RedirectView, View
 from django.urls import reverse_lazy
 from django.shortcuts import redirect
@@ -398,6 +398,16 @@ class ProfileApiView(RetrieveAPIView):
             'profile'
         )
         return qs.first().profile
+
+
+class HeartbeatApiView(RetrieveAPIView):
+    """ View to retrieve last timestamps for data received per stream """
+
+    def get(self, request):
+        last_timestamps = {
+            'hop': cache.get('hop_stream_heartbeat')
+        }
+        return Response(last_timestamps)
 
 
 class RevokeApiTokenApiView(APIView):

--- a/hermes_base/urls.py
+++ b/hermes_base/urls.py
@@ -38,6 +38,7 @@ urlpatterns = [
     path('auth/', include('mozilla_django_oidc.urls')),
     path('', include('hermes.urls')),
     path('api/v0/', include(router.urls)),
+    path('api/v0/heartbeat/', views.HeartbeatApiView.as_view(), name='heartbeat'),
     path('api/v0/profile/', views.ProfileApiView.as_view(), name='profile'),
     path('api/v0/revoke_api_token/', views.RevokeApiTokenApiView.as_view(), name='revoke_api_token'),
     path('api/v0/revoke_hop_credential/', views.RevokeHopCredentialApiView.as_view(), name='revoke_hop_credential')


### PR DESCRIPTION
Stores latest hop heartbeat message timestamp in cache, and serves it up via an api endpoint /heartbeat. 

Anyone have any idea why `sys.heartbeat-cit` is used vs `sys.heartbeat` (which seems to have no messages coming through)? 