### PR TITLE
Fix/make deployment more robust

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,6 @@
-helmPipeline()
+def config = [
+  devDeploymentTimeout: "300s",
+  prodDeploymentTimeout: "300s",
+]
+
+helmPipeline(config)

--- a/helm-chart/templates/deployment.yaml
+++ b/helm-chart/templates/deployment.yaml
@@ -48,6 +48,32 @@ spec:
             limits:
               cpu: 50m
               memory: 16Mi
+        # wait for redis cache to become ready
+        - name: check-cache-ready
+          image: "redis:7.0-alpine"
+          imagePullPolicy: IfNotPresent
+          command:
+            - sh
+            - -c
+            - >
+              until redis-cli \
+                  -u {{ include "hermes.cacheLocation" . | quote }} \
+                  ping | grep PONG;
+                do echo waiting for redis cache;
+                sleep 2;
+                done;
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            readOnlyRootFilesystem: true
+          resources:
+            requests:
+              cpu: 50m
+              memory: 16Mi
+            limits:
+              cpu: 50m
+              memory: 16Mi
         {{- if .Values.applyDatabaseMigrations }}
         - name: apply-db-migrations
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/helm-chart/templates/ingester.yaml
+++ b/helm-chart/templates/ingester.yaml
@@ -48,6 +48,32 @@ spec:
             limits:
               cpu: 50m
               memory: 16Mi
+        # wait for redis cache to become ready
+        - name: check-cache-ready
+          image: "redis:7.0-alpine"
+          imagePullPolicy: IfNotPresent
+          command:
+            - sh
+            - -c
+            - >
+              until redis-cli \
+                  -u {{ include "hermes.cacheLocation" . | quote }} \
+                  ping | grep PONG;
+                do echo waiting for redis cache;
+                sleep 2;
+                done;
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            readOnlyRootFilesystem: true
+          resources:
+            requests:
+              cpu: 50m
+              memory: 16Mi
+            limits:
+              cpu: 50m
+              memory: 16Mi
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
1. Adds config to the `helmPipeline()` (in Jenkinsfile) to extend the timeout to 300s (from default of 120s)
2. Adds the `check-cache-ready` initContainer to ping  configured redis cache and check for PONG response

Shall we add the initContainer to `deployment.yaml` as well?