### PR TITLE
Feature/tns file upload

### DIFF
--- a/hermes/serializers.py
+++ b/hermes/serializers.py
@@ -512,6 +512,7 @@ class GenericHermesDataSerializer(RemoveNullSerializer):
 
 
 class HermesMessageSerializer(serializers.Serializer):
+    files = serializers.ListField(child=serializers.FileField(allow_empty_file=False, use_url=False), required=False, allow_null=True)
     title = serializers.CharField(required=True)
     topic = serializers.CharField(required=True)
     message_text = serializers.CharField(required=False, default='', allow_blank=True)
@@ -601,6 +602,10 @@ class HermesMessageSerializer(serializers.Serializer):
             # Do extra TNS submission validation here
             tns_options = get_reverse_tns_values()
             full_error = defaultdict(dict)
+
+            request = self.context.get('request')
+            if request and not request.user.is_authenticated:
+                full_error['non_field_errors'] = [_('Must be an authenticated user to submit to TNS')]
 
             targets = validated_data.get('data', {}).get('targets', [])
             photometry_data = validated_data.get('data', {}).get('photometry', [])
@@ -709,20 +714,20 @@ class HermesMessageSerializer(serializers.Serializer):
             title = validated_data.get('title', '')
             full_error = defaultdict(dict)
             if len(title) == 0:
-                full_error['non_field_errors'] = [_('Title must be set to submit to GCN')]
+                full_error['title'] = [_('Title must be set to submit to GCN')]
                 raise serializers.ValidationError(full_error)
-            gcn_errors = []
+            gcn_title_errors = []
             if not any(key in title for key in self.GCN_REQUIRED_KEYS):
-                gcn_errors.append(_('Title must contain one of allowed subject keywords from the'
+                gcn_title_errors.append(_('Title must contain one of allowed subject keywords from the'
                                     ' <a href="https://gcn.nasa.gov/docs/circulars/styleguide">GCN Style Guide</a>'
                                     ' to submit to GCN.'))
             for key in self.GCN_PROHIBITED_KEYS:
                 if key in title:
-                    gcn_errors.append(_('Title cannot contain the prohibited keyword "{}". Please see the'
+                    gcn_title_errors.append(_('Title cannot contain the prohibited keyword "{}". Please see the'
                                         ' <a href="https://gcn.nasa.gov/docs/circulars/styleguide">GCN Style'
                                         ' Guide</a>.'.format(key)))
-            if gcn_errors:
-                full_error['non_field_errors'] = gcn_errors
+            if gcn_title_errors:
+                full_error['title'] = gcn_title_errors
                 raise serializers.ValidationError(full_error)
         # Remove the flags from the serialized response sent through hop
         if 'submit_to_tns' in validated_data:

--- a/hermes/test/test_tns.py
+++ b/hermes/test/test_tns.py
@@ -81,7 +81,7 @@ class TestTNS(TestCase):
         }
 
     def test_tns_conversion(self, mock_populate_tns):
-        tns_message = convert_hermes_message_to_tns(self.hermes_message)
+        tns_message = convert_hermes_message_to_tns(self.hermes_message, filenames=[])
         expected_tns_message = {'0': {'at_type': '1',
        'dec': {'error': None, 'units': None, 'value': '42.2'},
        'discovery_data_source_id': '5',

--- a/hermes/tns.py
+++ b/hermes/tns.py
@@ -192,11 +192,12 @@ def convert_hermes_message_to_tns(hermes_message, filenames):
                 report['photometry']['photometry_group'][str(i)] = report_photometry
                 i += 1
         if filenames:
+            file_comments = hermes_message.get('file_comments', [])
             report['related_files'] = {}
             for i, filename in enumerate(filenames):
                 report['related_files'][str(i)] = {
                     'related_file_name': filename,
-                    'related_file_comments': 'Submitted through Hermes'
+                    'related_file_comments': file_comments[i] if file_comments else 'Submitted through Hermes'
                 }
 
         at_report[str(len(at_report))] = report
@@ -236,7 +237,6 @@ def submit_files_to_tns(files):
         return filenames
     except Exception:
         raise BadTnsRequest("Failed to upload files to TNS, please try again later")
-    return []
 
 
 def submit_at_report_to_tns(at_report):

--- a/hermes/views.py
+++ b/hermes/views.py
@@ -393,6 +393,8 @@ class SubmitHermesMessageViewSet(viewsets.ViewSet):
             try:
                 if 'files' in data:
                     del data['files']
+                if 'file_comments' in data:
+                    del data['file_comments']
                 message_uuid = submit_to_hop(request, data)
             except APIException as ae:
                 return Response({'error': str(ae)}, status.HTTP_400_BAD_REQUEST)

--- a/hermes/views.py
+++ b/hermes/views.py
@@ -20,6 +20,7 @@ from rest_framework.exceptions import APIException
 from rest_framework import status, viewsets, filters
 from rest_framework.response import Response
 from rest_framework.views import APIView
+from rest_framework.parsers import JSONParser
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.generics import RetrieveAPIView
 from rest_framework.authtoken.models import Token
@@ -31,8 +32,8 @@ from hop.auth import Auth
 from hermes.brokers import hopskotch
 from hermes.models import Message, Target, NonLocalizedEvent, NonLocalizedEventSequence
 from hermes.forms import MessageForm
-from hermes.tns import get_tns_values, convert_hermes_message_to_tns, submit_to_tns, BadTnsRequest
-from hermes.utils import get_all_public_topics, convert_to_plaintext, send_email
+from hermes.tns import get_tns_values, convert_hermes_message_to_tns, submit_at_report_to_tns, submit_files_to_tns, BadTnsRequest
+from hermes.utils import get_all_public_topics, convert_to_plaintext, send_email, MultipartJsonFileParser
 from hermes.filters import MessageFilter, TargetFilter, NonLocalizedEventFilter, NonLocalizedEventSequenceFilter
 from hermes.serializers import (MessageSerializer, TargetSerializer, NonLocalizedEventSerializer, HermesMessageSerializer,
                                 NonLocalizedEventSequenceSerializer, ProfileSerializer)
@@ -214,8 +215,9 @@ def submit_to_gcn(request, message, message_uuid):
 
 
 class SubmitHermesMessageViewSet(viewsets.ViewSet):
-    serializer_class = HermesMessageSerializer
     EXPECTED_DATA_KEYS = ['targets', 'event_id', 'references', 'photometry', 'spectroscopy', 'astrometry']
+    serializer_class = HermesMessageSerializer
+    parser_classes = (MultipartJsonFileParser, JSONParser)
 
     def get(self, request, *args, **kwargs):
         message = """This endpoint is used to send a generic hermes message
@@ -355,11 +357,17 @@ class SubmitHermesMessageViewSet(viewsets.ViewSet):
         return Response({"message": message}, status.HTTP_200_OK)
 
     def create(self, request, *args, **kwargs):
-        non_serialized_data = {key: val for key, val in request.data.get('data', {}).items() if key not in self.EXPECTED_DATA_KEYS}
-        gcn_submit = request.data.get('submit_to_gcn', False)
-        tns_submit = request.data.get('submit_to_tns', False)
-        serializer = self.serializer_class(data=request.data, context={'request': request})
-
+        # This method can now handle either json encoded data, or multipart/form-data with json and files.
+        data = request.data
+        if 'multipart/form-data' in request.content_type:
+            files = request.data.getlist('files')  # Need to explicitly pull out the files since they don't translate well in .dict()
+            data = data.dict()
+            if 'files' in data:
+                data['files'] = files
+        non_serialized_data = {key: val for key, val in data.get('data', {}).items() if key not in self.EXPECTED_DATA_KEYS}
+        gcn_submit = data.get('submit_to_gcn', False)
+        tns_submit = data.get('submit_to_tns', False)
+        serializer = self.serializer_class(data=data, context={'request': request})
         if serializer.is_valid():
             data = serializer.validated_data
             if non_serialized_data:
@@ -368,8 +376,11 @@ class SubmitHermesMessageViewSet(viewsets.ViewSet):
                 data['data'].update(non_serialized_data)
             if tns_submit:
                 try:
-                    tns_message = convert_hermes_message_to_tns(data)
-                    object_name = submit_to_tns(tns_message)
+                    filenames = []
+                    if 'files' in data:
+                        filenames = submit_files_to_tns(data['files'])
+                    tns_message = convert_hermes_message_to_tns(data, filenames)
+                    object_name = submit_at_report_to_tns(tns_message)
                     if 'references' not in data['data']:
                         data['data']['references'] = []
                     data['data']['references'].append({
@@ -379,7 +390,12 @@ class SubmitHermesMessageViewSet(viewsets.ViewSet):
                     })
                 except BadTnsRequest as btr:
                     return Response({'error': str(btr)}, status.HTTP_400_BAD_REQUEST)
-            message_uuid = submit_to_hop(request, data)
+            try:
+                if 'files' in data:
+                    del data['files']
+                message_uuid = submit_to_hop(request, data)
+            except APIException as ae:
+                return Response({'error': str(ae)}, status.HTTP_400_BAD_REQUEST)
             if gcn_submit:
                 # TODO: I don't really know what we should do here if the GCN submission fails
                 return submit_to_gcn(request, data, message_uuid)


### PR DESCRIPTION
The backend 'submit_message' endpoint is changed to accept multipart/form-data data with files in a specific format, in addition to still supporting the plain json data like it did before. If we are submitting to tns and have files, it will upload those files first to TNS, then add them to the TNS at_report before submission to associate them with that report, and finally send the hermes message with a link to the created tns object.

I also changed rules to only allow TNS submission for authenticated users since that seemed sensible