### PR TITLE
Feature/tns classification

### DIFF
--- a/hermes/serializers.py
+++ b/hermes/serializers.py
@@ -671,16 +671,27 @@ class HermesMessageSerializer(serializers.Serializer):
             spectroscopy_data = validated_data.get('data', {}).get('spectroscopy', [])
             target_non_field_errors = []
             photometry_non_field_errors = []
+            spectroscopy_non_field_errors = []
             if len(targets) == 0:
                 target_non_field_errors.append(_('Must fill in at least one target entry for TNS submission'))
-            if len(photometry_data) == 0 and len(spectroscopy_data) == 0:
-                photometry_non_field_errors.append(_('Must fill in at least one photometry or spectroscopy entry for TNS submission'))
+
+            is_discovery = False
+            is_classification = False
+            tns_type_error = 'Should either fill in photometry (new discovery) or spectroscopy (classification) for TNS submission'
+            if len(photometry_data) > 0 and len(spectroscopy_data) > 0:
+                photometry_non_field_errors.append(_(tns_type_error))
+                spectroscopy_non_field_errors.append(_(tns_type_error))
+            elif len(spectroscopy_data) > 0:
+                is_classification = True
+            elif len(photometry_data) > 0:
+                is_discovery = True
+            else:
+                photometry_non_field_errors.append(_(tns_type_error))
+                spectroscopy_non_field_errors.append(_(tns_type_error))
 
             targets_errors = []
             for target in targets:
                 target_error = {}
-                if not target.get('new_discovery', True):
-                    target_error['new_discovery'] = [_("Target new_discovery must be set to True for TNS submission")]
                 if target.get('ra') is None:
                     target_error['ra'] = [_("Target ra must be present for TNS submission")]
                 if target.get('dec') is None:
@@ -698,73 +709,91 @@ class HermesMessageSerializer(serializers.Serializer):
                                                             " submission")]
                 elif discovery_info.get('reporting_group') not in tns_options.get('groups'):
                     discovery_error['reporting_group'] = [_(f"Discovery reporting group {discovery_info.get('reporting_group')} is not a valid TNS group")]
-                if not discovery_info or not discovery_info.get('discovery_source'):
-                    discovery_error['discovery_source'] = [_("Target must have discovery info discovery source for TNS"
-                                                             " submission")]
-                elif discovery_info.get('discovery_source') not in tns_options.get('groups'):
-                    discovery_error['discovery_source'] = [_(f"Discovery source group {discovery_info.get('discovery_source')} is not a valid TNS group")]
+                if not is_classification:
+                    if not target.get('new_discovery', True):
+                        target_error['new_discovery'] = [_("Target new_discovery must be set to True for TNS submission")]
+                    if not discovery_info or not discovery_info.get('discovery_source'):
+                        discovery_error['discovery_source'] = [_("Target must have discovery info discovery source for TNS"
+                                                                " submission")]
+                    elif discovery_info.get('discovery_source') not in tns_options.get('groups'):
+                        discovery_error['discovery_source'] = [_(f"Discovery source group {discovery_info.get('discovery_source')} is not a valid TNS group")]
                 if discovery_error:
                     target_error['discovery_info'] = discovery_error
                 targets_errors.append(target_error)
             if any(targets_errors):
                 full_error['data']['targets'] = targets_errors
 
-            photometry_errors = []
-            has_nondetection = False
-            has_detection = False
-            for photometry in photometry_data:
-                photometry_error = {}
-                if photometry.get('brightness'):
-                    has_detection = True
-                if not photometry.get('instrument'):
-                    photometry_error['instrument'] = [_('Photometry must have instrument specified for TNS submission')]
-                elif photometry.get('instrument') not in tns_options.get('instruments'):
-                    photometry_error['instrument'] = [_(f'Instrument {photometry.get("instrument")} is not a valid TNS instrument')]
-                if photometry.get('bandpass') not in tns_options.get('filters'):
-                    photometry_error['bandpass'] = [_(f'Bandpass {photometry.get("bandpass")} is not a valid TNS filter')]
-                if photometry.get('telescope') and photometry.get('telescope') not in tns_options.get('telescopes'):
-                    photometry_error['telescope'] = [_(f'Telescope {photometry.get("telescope")} is not a valid TNS telescope')]
-                if photometry.get('limiting_brightness'):
-                    has_nondetection = True
-                photometry_errors.append(photometry_error)
-            if any(photometry_errors):
-                full_error['data']['photometry'] = photometry_errors
+            if is_discovery:
+                photometry_errors = []
+                has_nondetection = False
+                has_detection = False
+                for photometry in photometry_data:
+                    photometry_error = {}
+                    if photometry.get('brightness'):
+                        has_detection = True
+                    if not photometry.get('instrument'):
+                        photometry_error['instrument'] = [_('Photometry must have instrument specified for TNS submission')]
+                    elif photometry.get('instrument') not in tns_options.get('instruments'):
+                        photometry_error['instrument'] = [_(f'Instrument {photometry.get("instrument")} is not a valid TNS instrument')]
+                    if photometry.get('bandpass') not in tns_options.get('filters'):
+                        photometry_error['bandpass'] = [_(f'Bandpass {photometry.get("bandpass")} is not a valid TNS filter')]
+                    if photometry.get('telescope') and photometry.get('telescope') not in tns_options.get('telescopes'):
+                        photometry_error['telescope'] = [_(f'Telescope {photometry.get("telescope")} is not a valid TNS telescope')]
+                    if photometry.get('limiting_brightness'):
+                        has_nondetection = True
+                    photometry_errors.append(photometry_error)
+                if any(photometry_errors):
+                    full_error['data']['photometry'] = photometry_errors
+                if not has_nondetection:
+                    photometry_non_field_errors.append(_(f'At least one photometry nondetection / limiting_brightness must be specified for TNS submission'))
+                if not has_detection:
+                    photometry_non_field_errors.append(_(f'At least one photometry detection / brightness must be specified for TNS submission'))
 
-            spectroscopy_errors = []
-            for spectroscopy in spectroscopy_data:
-                spectroscopy_error = {}
-                classification = spectroscopy.get('classification')
-                if classification and classification not in tns_options.get('object_types'):
-                    spectroscopy_error['classification'] = [_('Must be one of the TNS classification object_types for TNS'
-                                                              ' submission')]
-                if not spectroscopy.get('instrument'):
-                    spectroscopy_error['instrument'] = [_('Spectroscopy must have instrument specified for TNS'
-                                                          ' submission')]
-                if not spectroscopy.get('observer'):
-                    spectroscopy_error['observer'] = [_('Spectroscopy must have observer specified for TNS submission')]
-                if not spectroscopy.get('reducer'):
-                    spectroscopy_error['reducer'] = [_('Spectroscopy must have reducer specified for TNS submission')]
-                if not spectroscopy.get('spec_type'):
-                    spectroscopy_error['spec_type'] = [_('Spectroscopy must have spec_type specified for TNS'
-                                                         ' submission')]
-                spectroscopy_errors.append(spectroscopy_error)
-            if any(spectroscopy_errors):
-                full_error['data']['spectroscopy'] = spectroscopy_errors
+            if is_classification:
+                spectroscopy_errors = []
+                for spectroscopy in spectroscopy_data:
+                    spectroscopy_error = {}
+                    classification = spectroscopy.get('classification')
+                    if classification and classification not in tns_options.get('object_types'):
+                        spectroscopy_error['classification'] = [_('Must be one of the TNS classification object_types for TNS'
+                                                                ' submission')]
+
+                    file_info = spectroscopy.get('file_info', [])
+                    file_error_msg = 'Must specify a .ascii or .fits spectrum file for each spectrum in a TNS classification submission'
+                    if len(file_info) == 0:
+                        spectroscopy_error['files'] = [_(file_error_msg)]
+                    else:
+                        if not any(['.fits' in file.get('name') or '.ascii' in file.get('name') for file in file_info]):
+                            spectroscopy_error['files'] = [_(file_error_msg)]
+                    if not spectroscopy.get('instrument'):
+                        spectroscopy_error['instrument'] = [_('Spectroscopy must have instrument specified for TNS'
+                                                            ' submission')]
+                    elif spectroscopy.get('instrument') not in tns_options.get('instruments'):
+                        spectroscopy_error['instrument'] = [_(f'Instrument {spectroscopy.get("instrument")} is not a valid TNS instrument')]
+                    if not spectroscopy.get('observer'):
+                        spectroscopy_error['observer'] = [_('Spectroscopy must have observer specified for TNS submission')]
+                    if not spectroscopy.get('classification'):
+                        spectroscopy_error['classification'] = [_('Spectroscopy must have a classification specified for TNS submission')]
+                    elif spectroscopy.get('classification') not in tns_options.get('object_types'):
+                        spectroscopy_error['classification'] = [_(f'Classification {spectroscopy.get("classification")} is not a valid TNS classification object_type')]
+                    if not spectroscopy.get('spec_type'):
+                        spectroscopy_error['spec_type'] = [_('Spectroscopy must have spec_type specified for TNS'
+                                                            ' submission')]
+                    spectroscopy_errors.append(spectroscopy_error)
+                if any(spectroscopy_errors):
+                    full_error['data']['spectroscopy'] = spectroscopy_errors
 
             if not validated_data.get('authors'):
                 full_error['authors'] = [_('Must set an author / reporter for TNS submission')]
-
-            if not has_nondetection:
-                photometry_non_field_errors.append(_(f'At least one photometry nondetection / limiting_brightness must be specified for TNS submission'))
-
-            if not has_detection:
-                photometry_non_field_errors.append(_(f'At least one photometry detection / brightness must be specified for TNS submission'))
 
             if target_non_field_errors:
                 full_error['target_non_field_errors'] = target_non_field_errors
 
             if photometry_non_field_errors:
                 full_error['photometry_non_field_errors'] = photometry_non_field_errors
+
+            if spectroscopy_non_field_errors:
+                full_error['spectroscopy_non_field_errors'] = spectroscopy_non_field_errors
 
             if full_error:
                 raise serializers.ValidationError(full_error)

--- a/hermes/test/test_api.py
+++ b/hermes/test/test_api.py
@@ -855,7 +855,7 @@ class TestTNSSubmission(TestBaseMessageApi):
             status_code=200
         )
         self.assertContains(result,
-            'Must specify a .ascii or .fits spectrum file for each spectrum in a TNS classification submission',
+            'Must specify a .ascii or .txt spectrum file for each spectrum in a TNS classification submission',
             status_code=200
         )
         self.assertContains(result, 'Spectroscopy must have observer specified for TNS submission', status_code=200)

--- a/hermes/test/test_tns.py
+++ b/hermes/test/test_tns.py
@@ -3,7 +3,7 @@ from django.conf import settings
 from django.utils import timezone
 from unittest.mock import patch, ANY
 
-from hermes.tns import reverse_tns_values, convert_hermes_message_to_tns, parse_date
+from hermes.tns import reverse_tns_values, convert_discovery_hermes_message_to_tns, parse_date
 
 import json
 import os
@@ -25,7 +25,7 @@ class TestTNS(TestCase):
         self.hermes_message = {
             'title': 'Test TNS submission message',
             'topic': 'hermes.test',
-            'message_text': 'This is a candidate message.',
+            'message_text': 'This isnt used by TNS.',
             'submitter': 'Hermes Guest',
             'submit_to_tns': True,
             'authors': 'Test Person1 <testperson1@gmail.com>, Test Person2 <testperson2@gmail.com>',
@@ -46,6 +46,7 @@ class TestTNS(TestCase):
                         'proprietary_period': 1,
                         'proprietary_period_units': 'years'
                     },
+                    'comments': 'This is a candidate message.',
                     'host_name': 'm33',
                     'host_redshift': 23,
                     'redshift': 17
@@ -81,7 +82,7 @@ class TestTNS(TestCase):
         }
 
     def test_tns_conversion(self, mock_populate_tns):
-        tns_message = convert_hermes_message_to_tns(self.hermes_message, filenames_mapping={})
+        tns_message = convert_discovery_hermes_message_to_tns(self.hermes_message, filenames_mapping={})
         expected_tns_message = {'0': {'at_type': '1',
        'dec': {'error': None, 'units': None, 'value': '42.2'},
        'discovery_data_source_id': '5',
@@ -115,6 +116,7 @@ class TestTNS(TestCase):
                               'proprietary_period_value': '1'},
        'proprietary_period_groups': ['1', '2', '5'],
        'ra': {'error': None, 'units': None, 'value': '33.2'},
+       'related_files': {},
        'remarks': 'This is a candidate message.',
        'reporter': 'Test Person1 <testperson1@gmail.com>, Test Person2 '
                    '<testperson2@gmail.com>',

--- a/hermes/tns.py
+++ b/hermes/tns.py
@@ -1,12 +1,15 @@
 import requests
 import time
+from datetime import datetime
 import json
 from urllib.parse import urljoin
 from dateutil.parser import parse
 from astropy.time import Time
+from collections import defaultdict
 
 from django.core.cache import cache
 from django.conf import settings
+from django.utils import timezone
 
 import logging
 logger = logging.getLogger(__name__)
@@ -91,9 +94,9 @@ def parse_date(date):
 
 def get_earliest_photometry(photometry_list, nondetection=False):
     """ Retrieve the earliest detection or nondetection photometry from a list """
-    earliest_photometry = photometry_list[0]
-    earliest_date = parse_date(photometry_list[0].get('date_obs'))
-    for photometry in photometry_list[1:]:
+    earliest_photometry = None
+    earliest_date = datetime.max.replace(tzinfo=timezone.utc)
+    for photometry in photometry_list:
         if not nondetection and not photometry.get('brightness', 0):
             continue
         elif nondetection and not photometry.get('limiting_brightness', 0):
@@ -120,17 +123,86 @@ def convert_flux_units(hermes_units):
         return '6'
 
 
-def convert_hermes_message_to_tns(hermes_message, filenames_mapping):
-    """ Converts from hermes message format into TNS at report format """
-    # TODO: Add support for associated files
-    # TODO: Add support for classification or frb reports
+def convert_classification_hermes_message_to_tns(hermes_message, target_filenames_mapping, spectroscopy_filenames_mapping):
+    """ Converts from a hermes message format into a TNS classification report format """
+    report_payload = {}
+    tns_options = get_reverse_tns_values()
+    data = hermes_message.get('data', {})
+    spectroscopy_by_target = defaultdict(list)
+    for spectra in data.get('spectroscopy', []):
+        spectroscopy_by_target[spectra['target_name']].append(spectra)
+    targets_by_name = {target['name']: target for target in data.get('targets', [])}
+
+    for k, target in enumerate(targets_by_name.values()):
+        if target['name'] in spectroscopy_by_target:
+            # This means we have at least one spectroscopy datum for this target, so make a classification report from it
+            classification_report = {
+                'related_files': {},
+                'spectra': {'spectra-group': {}}
+            }
+            discovery_info = target.get('discovery_info', {})
+            groups = target.get('group_associations', [])
+            classification_report['name'] = target['name']
+            classification_report['classifier'] = hermes_message.get('authors')
+            classification_report['groupid'] = str(tns_options.get('groups', {}).get(discovery_info.get('reporting_group'), -1))
+            classification_report['class_proprietary_period_groups'] = [str(tns_options.get('groups', {}).get(group, -1)) for group in groups]
+            classification_report['remarks'] = target.get('comments', '')
+            if target.get('redshift'):
+                classification_report['redshift'] = target.get('redshift')
+
+            first_spectra = spectroscopy_by_target[target['name']][0]
+            # Set classification object_type from the first spectrum
+            classification_report['objtypeid'] = str(tns_options.get('object_types', {}).get(first_spectra.get('classification'), -1))
+            # Proprietary period of the classification uses the targets discovery info proprietary period but should be left to 0 usually
+            classification_report['class_proprietary_period'] = {
+                'class_proprietary_period_value': str(discovery_info.get('proprietary_period', 0)),
+                'class_proprietary_period_units': discovery_info.get('proprietary_period_units', 'Days').lower()
+            }
+            for i, spectra in enumerate(spectroscopy_by_target[target['name']]):
+                spectra_report = {
+                    'obsdate': parse_date(spectra.get('date_obs')).strftime('%Y-%m-%d %H:%M:%S'),
+                    'instrumentid': str(tns_options.get('instruments', {}).get(spectra.get('instrument'))),
+                    'exptime': str(spectra.get('exposure_time', '')),
+                    'observer': spectra.get('observer'),
+                    'spectypeid': str(tns_options.get('spectra_types', {}).get(spectra.get('spec_type'))),
+                    'remarks': spectra.get('comments', ''),
+                    'spec_proprietary_period': {
+                        'spec_proprietary_period_value': str(spectra.get('proprietary_period', 0)),
+                        'spec_proprietary_period_units': spectra.get('proprietary_period_units', 'Days').lower()
+                    }
+                }
+                if spectra.get('reducer'):
+                    spectra_report['reducer'] = spectra.get('reducer')
+                # Now add either an ascii or fits file to the payload based on which it was that was added
+                for file_info in spectra.get('file_info', []):
+                    if '.ascii' in file_info.get('name') or '.txt' in file_info.get('name'):
+                        if file_info.get('name') in spectroscopy_filenames_mapping:
+                            spectra_report['ascii_file'] = spectroscopy_filenames_mapping[file_info.get('name')]
+                    elif '.fits' in file_info.get('name'):
+                        if file_info.get('name') in spectroscopy_filenames_mapping:
+                            spectra_report['fits_file'] = spectroscopy_filenames_mapping[file_info.get('name')]
+                classification_report['spectra']['spectra-group'][str(i)] = spectra_report
+            # Now add the related files associated with a target
+            for i, file_info in enumerate(target.get('file_info', [])):
+                if target_filenames_mapping and file_info.get('name') in target_filenames_mapping:
+                    classification_report['related_files'][str(i)] = {
+                        'related_file_name': target_filenames_mapping[file_info.get('name')],
+                        'related_file_comments': file_info.get('description', '')
+                    }
+            report_payload[str(k)] = classification_report
+
+    return report_payload
+
+
+def convert_discovery_hermes_message_to_tns(hermes_message, filenames_mapping):
+    """ Converts from a hermes message format into a TNS AT (new discovery) report format """
     at_report = {}
     tns_options = get_reverse_tns_values()
     data = hermes_message.get('data', {})
     for target in data.get('targets', []):
         photometry_list = [photometry for photometry in data.get('photometry', []) if photometry.get('target_name') == target.get('name')]
         earliest_photometry = get_earliest_photometry(photometry_list)
-        report = {}
+        report = {'related_files': {}}
         report['ra'] = {
             'value': target.get('ra'),
             'error': target.get('ra_error'),
@@ -151,7 +223,7 @@ def convert_hermes_message_to_tns(hermes_message, filenames_mapping):
         report['host_redshift'] = target.get('host_redshift', '')
         report['transient_redshift'] = target.get('redshift', '')
         report['internal_name'] = target.get('name', '')
-        report['remarks'] = hermes_message.get('message_text')
+        report['remarks'] = target.get('comments', '')
         groups = target.get('group_associations', [])
         report['proprietary_period_groups'] = [str(tns_options.get('groups', {}).get(group, -1)) for group in groups]
         if discovery_info.get('proprietary_period'):
@@ -166,7 +238,7 @@ def convert_hermes_message_to_tns(hermes_message, filenames_mapping):
                 'limiting_flux': earliest_nondetection.get('limiting_brightness'),
                 'flux_units': convert_flux_units(earliest_nondetection.get('limiting_brightness_unit', 'AB mag')),
                 'filter_value': str(tns_options.get('filters', {}).get(earliest_nondetection.get('bandpass'))),
-                'instrument_value': str(tns_options.get('instruments', []).get(earliest_nondetection.get('instrument',))),
+                'instrument_value': str(tns_options.get('instruments', {}).get(earliest_nondetection.get('instrument'))),
                 'exptime': str(earliest_nondetection.get('exposure_time', '')),
                 'observer': earliest_nondetection.get('observer', ''),
                 'comments': earliest_nondetection.get('comments', ''),
@@ -191,16 +263,12 @@ def convert_hermes_message_to_tns(hermes_message, filenames_mapping):
                 }
                 report['photometry']['photometry_group'][str(i)] = report_photometry
                 i += 1
-        if filenames_mapping:
-            file_descriptions_by_name = {
-                file.get('name'): file.get(
-                    'description', 'Submitted through Hermes') for file in hermes_message.get('file_info', [])
-            }
-            report['related_files'] = {}
-            for i, filename in enumerate(filenames_mapping.keys()):
+
+        for i, file_info in enumerate(target.get('file_info', [])):
+            if filenames_mapping and file_info.get('name') in filenames_mapping:
                 report['related_files'][str(i)] = {
-                    'related_file_name': filenames_mapping[filename],
-                    'related_file_comments': file_descriptions_by_name[filename]
+                    'related_file_name': filenames_mapping[file_info.get('name')],
+                    'related_file_comments': file_info.get('description')
                 }
 
         at_report[str(len(at_report))] = report
@@ -225,11 +293,13 @@ def get_tns_api_token(request):
 
 
 def parse_object_from_tns_response(response_json):
-    at_report_response = response_json.get('data', {}).get('feedback', {}).get('at_report', {})[0]
-    for value in at_report_response.values():
-        if isinstance(value, dict) and 'objname' in value:
-            return value['objname']
-    return None
+    at_report_response = response_json.get('data', {}).get('feedback', {}).get('at_report', [])
+    object_names = []
+    for at_report_feedback in at_report_response:
+        for value in at_report_feedback.values():
+            if isinstance(value, dict) and 'objname' in value:
+                object_names.append(value['objname'])
+    return object_names
 
 
 def submit_files_to_tns(request, files):
@@ -257,9 +327,33 @@ def submit_files_to_tns(request, files):
         raise BadTnsRequest("Failed to upload files to TNS, please try again later")
 
 
+def submit_classification_report_to_tns(request, classification_report):
+    """ Submit a tns formatted classification report message to the tns server """
+    data = {'classification_report': classification_report}
+    response = submit_report_to_tns(request, data)
+    if response.get('id_code', 0) != 200:
+        raise BadTnsRequest(f"TNS classification submission failed. The response was: {response}")
+    return response
+
+
 def submit_at_report_to_tns(request, at_report):
-    """ Submit a tns formatted message to the tns server, and returns the TNS object name """
+    """ Submit a tns formatted AT report message to the tns server, and returns the TNS object names """
     data = {'at_report': at_report}
+    response = submit_report_to_tns(request, data)
+    object_names = []
+    if isinstance(response, dict):
+        object_names = parse_object_from_tns_response(response)
+
+    if not object_names:
+        raise BadTnsRequest(f"TNS submission failed to be processed within 10 seconds. The report_id = {response}")
+    return object_names
+
+
+def submit_report_to_tns(request, data):
+    """ Submits to the TNS bulk submission API. This first submits the payload, gets a report_id, and then queries for
+        that report_id to track its completion. Once completed, the response is returned, or if we time out the
+        report_id is returned instead.
+    """
     payload = {
         'api_key': get_tns_api_token(request),
         'data': json.dumps(data, indent=4)
@@ -271,10 +365,9 @@ def submit_at_report_to_tns(request, at_report):
         response.raise_for_status()
         report_id = response.json()['data']['report_id']
     except Exception:
-        raise Exception
+        raise BadTnsRequest("Failed to submit report to TNS")
 
     attempts = 0
-    object_name = None
     reply_url = urljoin(settings.TNS_BASE_URL, 'api/bulk-report-reply')
     reply_data = {'api_key': get_tns_api_token(request), 'report_id': report_id}
     # TNS Submissions return immediately with an id, which you must then check to see if the message
@@ -291,8 +384,5 @@ def submit_at_report_to_tns(request, at_report):
             raise BadTnsRequest(f"TNS submission failed with feedback: {response.json().get('data', {}).get('feedback', {})}")
         # A 200 response means the report was successful and we can parse out the object name
         elif response.status_code == 200:
-            object_name = parse_object_from_tns_response(response.json())
-            break
-    if not object_name:
-        raise BadTnsRequest(f"TNS submission failed to be processed within 10 seconds. The report_id = {report_id}")
-    return object_name
+            return response.json()
+    return report_id

--- a/hermes/utils.py
+++ b/hermes/utils.py
@@ -25,78 +25,6 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-TNS_TYPES = [
-    'Afterglow',
-    'AGN',
-    'Computed-Ia',
-    'Computed-IIb',
-    'Computed-IIn',
-    'Computed-IIP',
-    'Computed-PISN',
-    'CV',
-    'FBOT',
-    'FRB',
-    'Galaxy',
-    'Gap',
-    'Gap I',
-    'Gap II',
-    'ILRT',
-    'Impostor-SN',
-    'Kilonova',
-    'LBV',
-    'Light-Echo',
-    'LRN',
-    'M dwarf',
-    'Nova',
-    'QSO',
-    'SLSN-I',
-    'SLSN-II',
-    'SLSN-R',
-    'SN',
-    'SN I',
-    'SN I-faint',
-    'SN I-rapid',
-    'SN Ia',
-    'SN Ia-91bg-like',
-    'SN Ia-91T-like',
-    'SN Ia-Ca-rich',
-    'SN Ia-CSM',
-    'SN Ia-pec',
-    'SN Ia-SC',
-    'SN Iax[02cx-like]',
-    'SN Ib',
-    'SN Ib-Ca-rich',
-    'SN Ib-pec',
-    'SN Ib/c',
-    'SN Ib/c-Ca-rich',
-    'SN Ibn',
-    'SN Ibn/Icn',
-    'SN Ic',
-    'SN Ic-BL',
-    'SN Ic-Ca-rich',
-    'SN Ic-pec',
-    'SN Icn',
-    'SN II',
-    'SN II-pec',
-    'SN IIb',
-    'SN IIL',
-    'SN IIn',
-    'SN IIn-pec',
-    'SN IIP',
-    'Std-spec',
-    'TDE',
-    'TDE-H',
-    'TDE-H-He',
-    'TDE-He',
-    'Varstar',
-    'WR',
-    'WR-WC',
-    'WR-WN',
-    'WR-WO',
-    'Other'
-]
-
-
 TARGET_ORDER = [
     'name',
     'ra',
@@ -258,6 +186,8 @@ def upload_file_to_hop(file, topic, auth):
     """
     # First generate a uuid for it
     id = uuid.uuid4()
+    # Seek to begining of file in case we already read to the end to send to TNS
+    file.file.seek(0)
     data = bson.dumps({'message': file.file.read(), 'headers': {'format': b"blob", "_id": id.bytes}})
     upload_url = urljoin(settings.SCIMMA_ARCHIVE_BASE_URL, f'topic/{topic}')
     try:

--- a/hermes/views.py
+++ b/hermes/views.py
@@ -1,4 +1,3 @@
-from http.client import responses
 import json
 import logging
 import uuid
@@ -7,7 +6,6 @@ import requests
 
 from django.contrib.auth.models import User
 from django.conf import settings
-from django.http import HttpResponse
 
 #from django.views.decorators.csrf import csrf_exempt
 from django.http import JsonResponse
@@ -36,8 +34,9 @@ from hop.models import JSONBlob
 from hermes.brokers import hopskotch
 from hermes.models import Message, Target, NonLocalizedEvent, NonLocalizedEventSequence, OAuthToken
 from hermes.forms import MessageForm
-from hermes.tns import get_tns_values, convert_hermes_message_to_tns, submit_at_report_to_tns, submit_files_to_tns, BadTnsRequest
-from hermes.utils import get_all_public_topics, convert_to_plaintext, send_email, MultipartJsonFileParser, upload_file_to_hop
+from hermes.tns import (get_tns_values, convert_discovery_hermes_message_to_tns, submit_at_report_to_tns, submit_files_to_tns,
+                        convert_classification_hermes_message_to_tns, submit_classification_report_to_tns, BadTnsRequest)
+from hermes.utils import get_all_public_topics, convert_to_plaintext, MultipartJsonFileParser, upload_file_to_hop
 from hermes.filters import MessageFilter, TargetFilter, NonLocalizedEventFilter, NonLocalizedEventSequenceFilter
 from hermes.serializers import (MessageSerializer, TargetSerializer, NonLocalizedEventSerializer, HermesMessageSerializer,
                                 NonLocalizedEventSequenceSerializer, ProfileSerializer)
@@ -282,7 +281,13 @@ class SubmitHermesMessageViewSet(viewsets.ViewSet):
                         'group one',
                         'group two',
                         ...
-                    ]
+                    ],
+                    file_info: [{
+                        name: <file name>,
+                        description: <file description>,
+                        url: <url to access file> (optional)
+                    }],
+                    comments: <String of comments for the target>,
                 }
             ],
             photometry: [
@@ -373,17 +378,17 @@ class SubmitHermesMessageViewSet(viewsets.ViewSet):
                 return Response({'error': f'User account does not have an associated SCIMMA auth credential. Please logout and log back in.'})
 
             data = serializer.validated_data
-            general_files = []
+            target_files = {}
             spectroscopy_files = {}
             referenced_files_not_found = []
-            # Check that if files are specified in the general message, they match top level files uploaded here
-            for file in data.get('file_info', []):
-                if not file.get('url'):
-                    if file.get('name') not in files_by_name:
-                        referenced_files_not_found.append(file.get('name'))
-                    else:
-                        general_files.append(files_by_name[file.get('name')])
-
+            # Check that if files are specified in the target section, they match top level files uploaded here
+            for target in data.get('data', {}).get('targets', []):
+                for file in target.get('file_info', []):
+                    if not file.get('url'):
+                        if file.get('name') not in files_by_name:
+                            referenced_files_not_found.append(file.get('name'))
+                        else:
+                            target_files[file.get('name')] = files_by_name[file.get('name')]
             # Check that if files are specified in spectroscopy sections, they match top level files uploaded here
             for spectroscopy_datum in data.get('data', {}).get('spectroscopy', []):
                 for file in spectroscopy_datum.get('file_info', []):
@@ -393,8 +398,18 @@ class SubmitHermesMessageViewSet(viewsets.ViewSet):
                         else:
                             spectroscopy_files[file.get('name')] = files_by_name[file.get('name')]
 
+            # Check that there are no files that were uploaded but not referenced in the messages data
+            files_not_referenced = []
+            if target_files or spectroscopy_files:
+                for filename in files_by_name.keys():
+                    if ((filename not in target_files) and (filename not in spectroscopy_files)):
+                        files_not_referenced.append(filename)
+
+            if files_not_referenced:
+                return Response({'error': f'Files {",".join(files_not_referenced)} sent but not referenced in the messages target or spectroscopy sections.'}, status.HTTP_400_BAD_REQUEST)
+
             if referenced_files_not_found:
-                return Response({'error': f'Files {",".join(referenced_files_not_found)} referenced in message but not uploaded in files section.'})
+                return Response({'error': f'Files {",".join(referenced_files_not_found)} referenced in message but not uploaded in files section.'}, status.HTTP_400_BAD_REQUEST)
 
             if non_serialized_data:
                 if 'data' not in data:
@@ -402,18 +417,32 @@ class SubmitHermesMessageViewSet(viewsets.ViewSet):
                 data['data'].update(non_serialized_data)
             if tns_submit:
                 try:
-                    filenames_mapping = {}
-                    if general_files:
-                        filenames_mapping = submit_files_to_tns(general_files)
-                    tns_message = convert_hermes_message_to_tns(data, filenames_mapping)
-                    object_name = submit_at_report_to_tns(tns_message)
+                    target_filenames_mapping = {}
+                    spectroscopy_filenames_mapping = {}
+                    if target_files:
+                        target_filenames_mapping = submit_files_to_tns(request, target_files.values())
+                    object_names = []
+                    if len(data.get('data', {}).get('spectroscopy', [])) > 0:
+                        # This is a classification message
+                        if spectroscopy_files:
+                            spectroscopy_filenames_mapping = submit_files_to_tns(request, spectroscopy_files.values())
+                        tns_message = convert_classification_hermes_message_to_tns(
+                            data, target_filenames_mapping, spectroscopy_filenames_mapping)
+                        output = submit_classification_report_to_tns(request, tns_message)
+                        object_names = list(
+                            {spectra.get('target_name') for spectra in data.get('data', {}).get('spectroscopy', [])}
+                        )
+                    else:
+                        tns_message = convert_discovery_hermes_message_to_tns(data, target_filenames_mapping)
+                        object_names = submit_at_report_to_tns(request, tns_message)
                     if 'references' not in data['data']:
                         data['data']['references'] = []
-                    data['data']['references'].append({
-                        'source': 'tns_object',
-                        'citation': object_name,
-                        'url': urljoin(settings.TNS_BASE_URL, f'object/{object_name}')
-                    })
+                    for object_name in object_names:
+                        data['data']['references'].append({
+                            'source': 'tns_object',
+                            'citation': object_name,
+                            'url': urljoin(settings.TNS_BASE_URL, f'object/{object_name}')
+                        })
                 except BadTnsRequest as btr:
                     return Response({'error': str(btr)}, status.HTTP_400_BAD_REQUEST)
             try:
@@ -423,12 +452,24 @@ class SubmitHermesMessageViewSet(viewsets.ViewSet):
                 # Check if there are spectroscopy files and upload them here, getting back a url to them
                 # Then store the reference in the messages data for the file_info->url
                 for spectroscopy_datum in data.get('data', {}).get('spectroscopy', []):
-                    for file in spectroscopy_datum.get('file_info', []):
-                        if not file.get('url'):
-                            filename = file.get('name')
-                            file_contents = spectroscopy_files[filename]
-                            download_url = upload_file_to_hop(file_contents, data['topic'], hop_auth)
-                            file['url'] = download_url
+                    # Only publicly upload spectrum file if the proprietary period is 0 or not set
+                    if spectroscopy_datum.get('proprietary_period', 0) == 0:
+                        for file in spectroscopy_datum.get('file_info', []):
+                            if not file.get('url'):
+                                filename = file.get('name')
+                                file_contents = spectroscopy_files[filename]
+                                download_url = upload_file_to_hop(file_contents, data['topic'], hop_auth)
+                                file['url'] = download_url
+                # Do the same for target related files
+                for target in data.get('data', {}).get('targets', []):
+                    # Only publicly upload target related file if the proprietary period is 0 or not set
+                    if target.get('discovery_info', {}).get('proprietary_period', 0):
+                        for file in target.get('file_info', []):
+                            if not file.get('url'):
+                                filename = file.get('name')
+                                file_contents = target_files[filename]
+                                download_url = upload_file_to_hop(file_contents, data['topic'], hop_auth)
+                                file['url'] = download_url
                 # return Response({'error': 'Temporarily stopped sending messages for testing'}, status.HTTP_400_BAD_REQUEST)
                 # Do this to generate the uuid early so we can send it with the gcn.
                 payload, headers = Producer.pack(data, metadata)

--- a/hermes/views.py
+++ b/hermes/views.py
@@ -190,7 +190,7 @@ def submit_to_gcn(request, message, message_uuid):
     message_plaintext += '\n\n This message was sent via HERMES.  A machine readable version can be found at ' \
                          + urljoin(settings.HERMES_FRONT_END_BASE_URL, f'message/{str(message_uuid)}')
     # Then submit the plaintext message to gcn via email
-    message_data = {'subject': message['title'], 'body': message_plaintext}
+    message_data = {'subject': message['title'], 'body': message_plaintext, "format": "text/markdown"}
     access_token = get_access_token(request.user, OAuthToken.IntegratedApps.GCN)
 
     headers =  {'Authorization': f'Bearer {access_token}'}
@@ -428,7 +428,7 @@ class SubmitHermesMessageViewSet(viewsets.ViewSet):
                             spectroscopy_filenames_mapping = submit_files_to_tns(request, spectroscopy_files.values())
                         tns_message = convert_classification_hermes_message_to_tns(
                             data, target_filenames_mapping, spectroscopy_filenames_mapping)
-                        output = submit_classification_report_to_tns(request, tns_message)
+                        submit_classification_report_to_tns(request, tns_message)
                         object_names = list(
                             {spectra.get('target_name') for spectra in data.get('data', {}).get('spectroscopy', [])}
                         )
@@ -463,7 +463,7 @@ class SubmitHermesMessageViewSet(viewsets.ViewSet):
                 # Do the same for target related files
                 for target in data.get('data', {}).get('targets', []):
                     # Only publicly upload target related file if the proprietary period is 0 or not set
-                    if target.get('discovery_info', {}).get('proprietary_period', 0):
+                    if target.get('discovery_info', {}).get('proprietary_period', 0) == 0:
                         for file in target.get('file_info', []):
                             if not file.get('url'):
                                 filename = file.get('name')


### PR DESCRIPTION
This moves general files to within targets, so there are target and spectroscopy specific files now. It also adds comments to the target. Support for TNS classification submissions is added, as well as multi-target / bulk submission of TNS discovery or classification reports. The serializer attempts to detect whether you are trying to submit a new discovery or classification based on if you add photometry or spectroscopy, and it does not allow both in one submission. Target or spectroscopy files are uploaded to the public SCIMMA archive if their proprietary periods are not set or set to 0 in their respective sections.