### PR TITLE
Feature/add tns archival fields

### DIFF
--- a/hermes/serializers.py
+++ b/hermes/serializers.py
@@ -307,6 +307,8 @@ class TargetDataSerializer(RemoveNullSerializer):
     redshift = serializers.FloatField(required=False, allow_null=True)
     host_name = serializers.CharField(required=False, allow_null=True)
     host_redshift = serializers.FloatField(required=False, allow_null=True)
+    nondetection_source = serializers.CharField(required=False, allow_null=True)
+    nondetection_comments = serializers.CharField(required=False, allow_null=True)
     aliases = serializers.ListField(child=serializers.CharField(), required=False)
     group_associations = serializers.ListField(child=serializers.CharField(), required=False, allow_null=True)
     file_info = FileInfoSerializer(required=False, many=True)
@@ -701,6 +703,9 @@ class HermesMessageSerializer(serializers.Serializer):
                     bad_groups = [group for group in groups if group not in tns_options.get('groups', [])]
                     if bad_groups:
                         target_error['group_associations'] = [_(f'Group associations {",".join(bad_groups)} are not valid TNS groups')]
+                nondetection_source = target.get('nondetection_source')
+                if nondetection_source and nondetection_source not in tns_options.get('archives'):
+                    target_error['nondetection_source'] = [_(f'Nondetection source {nondetection_source} is not a valid TNS Archive')]
 
                 discovery_info = target.get('discovery_info', {})
                 discovery_error = {}
@@ -724,13 +729,17 @@ class HermesMessageSerializer(serializers.Serializer):
                 full_error['data']['targets'] = targets_errors
 
             if is_discovery:
+                targets_by_target_name = {target.get('name'): target for target  in targets}
                 photometry_errors = []
                 has_nondetection = False
                 has_detection = False
                 for photometry in photometry_data:
                     photometry_error = {}
+                    related_target = targets_by_target_name.get(photometry.get('target_name'))
                     if photometry.get('brightness'):
                         has_detection = True
+                    if photometry.get('limiting_brightness') or related_target.get('nondetection_source'):
+                        has_nondetection = True
                     if not photometry.get('instrument'):
                         photometry_error['instrument'] = [_('Photometry must have instrument specified for TNS submission')]
                     elif photometry.get('instrument') not in tns_options.get('instruments'):
@@ -739,13 +748,11 @@ class HermesMessageSerializer(serializers.Serializer):
                         photometry_error['bandpass'] = [_(f'Bandpass {photometry.get("bandpass")} is not a valid TNS filter')]
                     if photometry.get('telescope') and photometry.get('telescope') not in tns_options.get('telescopes'):
                         photometry_error['telescope'] = [_(f'Telescope {photometry.get("telescope")} is not a valid TNS telescope')]
-                    if photometry.get('limiting_brightness'):
-                        has_nondetection = True
                     photometry_errors.append(photometry_error)
                 if any(photometry_errors):
                     full_error['data']['photometry'] = photometry_errors
                 if not has_nondetection:
-                    photometry_non_field_errors.append(_(f'At least one photometry nondetection / limiting_brightness must be specified for TNS submission'))
+                    photometry_non_field_errors.append(_(f'At least one photometry nondetection / limiting_brightness or target nondetection_source must be specified for TNS submission'))
                 if not has_detection:
                     photometry_non_field_errors.append(_(f'At least one photometry detection / brightness must be specified for TNS submission'))
 

--- a/hermes/serializers.py
+++ b/hermes/serializers.py
@@ -713,7 +713,7 @@ class HermesMessageSerializer(serializers.Serializer):
                     discovery_error['reporting_group'] = [_(f"Discovery reporting group {discovery_info.get('reporting_group')} is not a valid TNS group")]
                 nondetection_source = discovery_info.get('nondetection_source')
                 if nondetection_source and nondetection_source not in tns_options.get('archives'):
-                    discovery_error['nondetection_source'] = [_(f'Discovery nondetection source {nondetection_source} is not a valid TNS Archive')]
+                    discovery_error['nondetection_source'] = [_(f'Discovery nondetection source {nondetection_source} is not a valid TNS archive')]
                 if not is_classification:
                     if not target.get('new_discovery', True):
                         target_error['new_discovery'] = [_("Target new_discovery must be set to True for TNS submission")]

--- a/hermes/serializers.py
+++ b/hermes/serializers.py
@@ -266,6 +266,7 @@ class OrbitalElementsSerializer(RemoveNullSerializer):
 
 
 class DiscoveryInfoSerializer(RemoveNullSerializer):
+    date = serializers.CharField(required=False, allow_null=True)
     reporting_group = serializers.CharField(required=False, allow_null=True)
     discovery_source = serializers.CharField(required=False, allow_null=True)
     transient_type = serializers.ChoiceField(required=False, default='Other',
@@ -276,6 +277,9 @@ class DiscoveryInfoSerializer(RemoveNullSerializer):
     nondetection_source = serializers.CharField(required=False, allow_null=True)
     nondetection_comments = serializers.CharField(required=False, allow_null=True)
 
+    def validate_date(self, value):
+        validate_date(value)
+        return value
 
 class FileInfoSerializer(RemoveNullSerializer):
     name = serializers.CharField(required=True)

--- a/hermes/test/test_api.py
+++ b/hermes/test/test_api.py
@@ -776,7 +776,7 @@ class TestTNSSubmission(TestBaseMessageApi):
         bad_message['data']['photometry'][0]['instrument'] = 'NotAnInstrument'
 
         result = self.client.post(reverse('submit_message-validate'), bad_message, content_type="application/json")
-        self.assertContains(result, 'Discovery nondetection source NotAnArchive is not a valid TNS Archive', status_code=200)
+        self.assertContains(result, 'Discovery nondetection source NotAnArchive is not a valid TNS archive', status_code=200)
         self.assertContains(result, 'Discovery reporting group Notagroup is not a valid TNS group', status_code=200)
         self.assertContains(result, 'Discovery source group Also Notagroup is not a valid TNS group', status_code=200)
         self.assertContains(result, 'Bandpass NotAFilter is not a valid TNS filter', status_code=200)

--- a/hermes/test/test_api.py
+++ b/hermes/test/test_api.py
@@ -768,15 +768,15 @@ class TestTNSSubmission(TestBaseMessageApi):
         bad_message = deepcopy(self.basic_message)
         bad_message['data']['targets'][0]['discovery_info'] = {
             'reporting_group': 'Notagroup',
-            'discovery_source': 'Also Notagroup'
+            'discovery_source': 'Also Notagroup',
+            'nondetection_source': 'NotAnArchive'
         }
-        bad_message['data']['targets'][0]['nondetection_source'] = 'NotAnArchive'
         bad_message['data']['photometry'][0]['bandpass'] = 'NotAFilter'
         bad_message['data']['photometry'][0]['telescope'] = 'NotATelescope'
         bad_message['data']['photometry'][0]['instrument'] = 'NotAnInstrument'
 
         result = self.client.post(reverse('submit_message-validate'), bad_message, content_type="application/json")
-        self.assertContains(result, 'Nondetection source NotAnArchive is not a valid TNS Archive', status_code=200)
+        self.assertContains(result, 'Discovery nondetection source NotAnArchive is not a valid TNS Archive', status_code=200)
         self.assertContains(result, 'Discovery reporting group Notagroup is not a valid TNS group', status_code=200)
         self.assertContains(result, 'Discovery source group Also Notagroup is not a valid TNS group', status_code=200)
         self.assertContains(result, 'Bandpass NotAFilter is not a valid TNS filter', status_code=200)
@@ -798,16 +798,16 @@ class TestTNSSubmission(TestBaseMessageApi):
         bad_message = deepcopy(self.basic_message)
         del bad_message['data']['photometry'][1]
         result = self.client.post(reverse('submit_message-validate'), bad_message, content_type="application/json")
-        self.assertContains(result, 'At least one photometry nondetection / limiting_brightness or target nondetection_source must be specified for TNS submission', status_code=200)
+        self.assertContains(result, 'At least one photometry nondetection / limiting_brightness or target discovery nondetection_source must be specified for TNS submission', status_code=200)
 
     def test_submission_accepts_nondetection_source(self, mock_populate_tns):
         good_message = deepcopy(self.basic_message)
         good_message['data']['targets'][0]['new_discovery'] = True
         good_message['data']['targets'][0]['discovery_info'] = {
             'reporting_group': 'SNEX',
-            'discovery_source': 'LCO Floyds'
+            'discovery_source': 'LCO Floyds',
+            'nondetection_source': 'DSS'
         }
-        good_message['data']['targets'][0]['nondetection_source'] = 'DSS'
         del good_message['data']['photometry'][1]
         result = self.client.post(reverse('submit_message-validate'), good_message, content_type="application/json")
         self.assertEqual(result.json(), {})

--- a/hermes/tns.py
+++ b/hermes/tns.py
@@ -236,7 +236,14 @@ def convert_discovery_hermes_message_to_tns(hermes_message, filenames_mapping):
                 'proprietary_period_units': discovery_info.get('proprietary_period_units').lower()
             }
         earliest_nondetection = get_earliest_photometry(photometry_list, nondetection=True)
-        if earliest_nondetection.get('limiting_brightness', 0):
+        # If nondetection_source info is present in the target, then use that
+        if target.get('nondetection_source'):
+            report['non_detection'] = {
+                'archiveid': str(tns_options.get('archives', {}).get(target.get('nondetection_source'))),
+                'archival_remarks': target.get('nondetection_comments', ''),
+            }
+        # Otherwise if real limiting_brightness is present in the nondetection, then use that instead
+        elif earliest_nondetection.get('limiting_brightness', 0):
             report['non_detection'] = {
                 'obsdate': parse_date(earliest_nondetection.get('date_obs')).strftime('%Y-%m-%d %H:%M:%S'),
                 'limiting_flux': earliest_nondetection.get('limiting_brightness'),

--- a/hermes/tns.py
+++ b/hermes/tns.py
@@ -221,7 +221,10 @@ def convert_discovery_hermes_message_to_tns(hermes_message, filenames_mapping):
         report['reporting_group_id'] = str(tns_options.get('groups', {}).get(discovery_info.get('reporting_group'), -1))
         report['discovery_data_source_id'] = str(tns_options.get('groups', {}).get(discovery_info.get('discovery_source'), -1))
         report['reporter'] = hermes_message.get('authors')
-        report['discovery_datetime'] = parse_date(earliest_photometry.get('date_obs')).strftime('%Y-%m-%d %H:%M:%S')
+        if discovery_info.get('date'):
+            report['discovery_datetime'] = parse_date(discovery_info.get('date')).strftime('%Y-%m-%d %H:%M:%S')
+        else:
+            report['discovery_datetime'] = parse_date(earliest_photometry.get('date_obs')).strftime('%Y-%m-%d %H:%M:%S')
         report['at_type'] = str(tns_options.get('at_types', {}).get(discovery_info.get('transient_type'), -1))
         report['host_name'] = target.get('host_name', '')
         report['host_redshift'] = target.get('host_redshift', '')

--- a/hermes/tns.py
+++ b/hermes/tns.py
@@ -237,10 +237,10 @@ def convert_discovery_hermes_message_to_tns(hermes_message, filenames_mapping):
             }
         earliest_nondetection = get_earliest_photometry(photometry_list, nondetection=True)
         # If nondetection_source info is present in the target, then use that
-        if target.get('nondetection_source'):
+        if discovery_info.get('nondetection_source'):
             report['non_detection'] = {
-                'archiveid': str(tns_options.get('archives', {}).get(target.get('nondetection_source'))),
-                'archival_remarks': target.get('nondetection_comments', ''),
+                'archiveid': str(tns_options.get('archives', {}).get(discovery_info.get('nondetection_source'))),
+                'archival_remarks': discovery_info.get('nondetection_comments', ''),
             }
         # Otherwise if real limiting_brightness is present in the nondetection, then use that instead
         elif earliest_nondetection.get('limiting_brightness', 0):

--- a/hermes/views.py
+++ b/hermes/views.py
@@ -272,6 +272,8 @@ class SubmitHermesMessageViewSet(viewsets.ViewSet):
                     redshift: <>,
                     host_name: <Host galaxy name>,
                     host_redshift: <Redshift (z) of Host Galaxy>,
+                    nondetection_source: <Source Catalog for the last nondetection of this target>,
+                    nondetection_comments: <Comments about the last nondetection of this target>,
                     aliases: [
                         'alias1',
                         'alias2',

--- a/hermes/views.py
+++ b/hermes/views.py
@@ -263,8 +263,9 @@ class SubmitHermesMessageViewSet(viewsets.ViewSet):
                         epoch_of_perihelion: <Epoch of Perihelion passage (tp) in MJD>
                     },
                     discovery_info: {
-                        reporting_group: <>,
-                        discovery_source: <>,
+                        date: <Discovery date for new discoveries>,
+                        reporting_group: <TNS reporting group for TNS new discoveries>,
+                        discovery_source: <TNS source group for TNS new discoveries>,
                         transient_type: <Type of source, one of PSN, nuc, PNV, AGN, or Other>,
                         proprietary_period: <Duration that this discovery should be kept private>,
                         proprietary_period_units: <Units for proprietary period, Days, seconds, Years>,

--- a/hermes/views.py
+++ b/hermes/views.py
@@ -267,13 +267,13 @@ class SubmitHermesMessageViewSet(viewsets.ViewSet):
                         discovery_source: <>,
                         transient_type: <Type of source, one of PSN, nuc, PNV, AGN, or Other>,
                         proprietary_period: <Duration that this discovery should be kept private>,
-                        proprietary_period_units: <Units for proprietary period, Days, seconds, Years>
+                        proprietary_period_units: <Units for proprietary period, Days, seconds, Years>,
+                        nondetection_source: <Source Catalog for the last nondetection of this target>,
+                        nondetection_comments: <Comments about the last nondetection of this target>,
                     },
                     redshift: <>,
                     host_name: <Host galaxy name>,
                     host_redshift: <Redshift (z) of Host Galaxy>,
-                    nondetection_source: <Source Catalog for the last nondetection of this target>,
-                    nondetection_comments: <Comments about the last nondetection of this target>,
                     aliases: [
                         'alias1',
                         'alias2',


### PR DESCRIPTION
This adds the `nondetection_source` and `nondetection_comments` fields to the Targets `discovery_info` subsection (since these relate primarily to a new discovery report). Changed the serializer validation and the TNS submission to check if either these new fields or a `limiting_brightness` is present, and first use these fields if they exist to submit to TNS.