### PR TITLE
Fix/tns 2 support

### DIFF
--- a/hermes/serializers.py
+++ b/hermes/serializers.py
@@ -770,8 +770,8 @@ class HermesMessageSerializer(serializers.Serializer):
                 for spectroscopy in spectroscopy_data:
                     spectroscopy_error = {}
                     classification = spectroscopy.get('classification')
-                    if classification and classification not in tns_options.get('object_types'):
-                        spectroscopy_error['classification'] = [_('Must be one of the TNS classification object_types for TNS'
+                    if classification and classification not in tns_options.get('objtypes'):
+                        spectroscopy_error['classification'] = [_('Must be one of the TNS classification objtypes for TNS'
                                                                 ' submission')]
 
                     file_info = spectroscopy.get('file_info', [])
@@ -790,7 +790,7 @@ class HermesMessageSerializer(serializers.Serializer):
                         spectroscopy_error['observer'] = [_('Spectroscopy must have observer specified for TNS submission')]
                     if not spectroscopy.get('classification'):
                         spectroscopy_error['classification'] = [_('Spectroscopy must have a classification specified for TNS submission')]
-                    elif spectroscopy.get('classification') not in tns_options.get('object_types'):
+                    elif spectroscopy.get('classification') not in tns_options.get('objtypes'):
                         spectroscopy_error['classification'] = [_(f'Classification {spectroscopy.get("classification")} is not a valid TNS classification object_type')]
                     if not spectroscopy.get('spec_type'):
                         spectroscopy_error['spec_type'] = [_('Spectroscopy must have spec_type specified for TNS'

--- a/hermes/serializers.py
+++ b/hermes/serializers.py
@@ -269,9 +269,12 @@ class DiscoveryInfoSerializer(RemoveNullSerializer):
     date = serializers.CharField(required=False, allow_null=True)
     reporting_group = serializers.CharField(required=False, allow_null=True)
     discovery_source = serializers.CharField(required=False, allow_null=True)
-    transient_type = serializers.ChoiceField(required=False, default='Other - Undefined',
-                                             choices=['PSN - Possible SN', 'NUC - Possibly nuclear', 'PNV - Possible Nova', 'AGN - Known AGN', 'FRB - Fast Radio Burst event', 'Other - Undefined'])
-    proprietary_period = serializers.FloatField(required=False, allow_null=True)
+    transient_type = serializers.ChoiceField(required=False, allow_null=True,
+                                             choices=['PSN - Possible SN', 'NUC - Possibly nuclear',
+                                                      'PNV - Possible Nova', 'AGN - Known AGN',
+                                                      'FRB - Fast Radio Burst event', 'Other - Undefined'])
+    proprietary_period = serializers.FloatField(
+        required=False, allow_null=True)
     proprietary_period_units = serializers.ChoiceField(required=False, default='Days',
                                                        choices=['Days', 'Months', 'Years'])
     nondetection_source = serializers.CharField(required=False, allow_null=True)
@@ -434,7 +437,7 @@ class SpectroscopyDataSerializer(CommonDataSerializer):
     comments = serializers.CharField(required=False, allow_null=True)
     observer = serializers.CharField(required=False, allow_null=True)
     reducer = serializers.CharField(required=False, allow_null=True)
-    spec_type = serializers.ChoiceField(required=False, choices=['Object', 'Host', 'Synthetic', 'Sky', 'Arcs'])
+    spec_type = serializers.ChoiceField(required=False, choices=['Object', 'Other', 'Host', 'Synthetic', 'Sky', 'Arcs'])
     file_info = FileInfoSerializer(required=False, many=True)
 
     def validate(self, data):
@@ -724,6 +727,8 @@ class HermesMessageSerializer(serializers.Serializer):
                     if not discovery_info or not discovery_info.get('discovery_source'):
                         discovery_error['discovery_source'] = [_("Target must have discovery info discovery source for TNS"
                                                                 " submission")]
+                    if not discovery_info or not discovery_info.get('transient_type'):
+                        discovery_error['transient_type'] = [_("Target must have a discovery info transient_type for TNS submission")]
                     elif discovery_info.get('discovery_source') not in tns_options.get('groups'):
                         discovery_error['discovery_source'] = [_(f"Discovery source group {discovery_info.get('discovery_source')} is not a valid TNS group")]
                 if discovery_error:

--- a/hermes/serializers.py
+++ b/hermes/serializers.py
@@ -269,8 +269,8 @@ class DiscoveryInfoSerializer(RemoveNullSerializer):
     date = serializers.CharField(required=False, allow_null=True)
     reporting_group = serializers.CharField(required=False, allow_null=True)
     discovery_source = serializers.CharField(required=False, allow_null=True)
-    transient_type = serializers.ChoiceField(required=False, default='Other',
-                                             choices=['PSN', 'NUC', 'PNV', 'AGN', 'FRB', 'Other'])
+    transient_type = serializers.ChoiceField(required=False, default='Other - Undefined',
+                                             choices=['PSN - Possible SN', 'NUC - Possibly nuclear', 'PNV - Possible Nova', 'AGN - Known AGN', 'FRB - Fast Radio Burst event', 'Other - Undefined'])
     proprietary_period = serializers.FloatField(required=False, allow_null=True)
     proprietary_period_units = serializers.ChoiceField(required=False, default='Days',
                                                        choices=['Days', 'Months', 'Years'])

--- a/hermes/test/test_tns.py
+++ b/hermes/test/test_tns.py
@@ -42,7 +42,7 @@ class TestTNS(TestCase):
                     'discovery_info': {
                         'discovery_source': 'LCO Floyds',
                         'reporting_group': 'SNEX',
-                        'transient_type': 'PSN',
+                        'transient_type': 'PSN - Possible SN',
                         'proprietary_period': 1,
                         'proprietary_period_units': 'years'
                     },

--- a/hermes/test/tns_options.json
+++ b/hermes/test/tns_options.json
@@ -1,13 +1,13 @@
 {
     "at_types": [
-        "Other",
-        "PSN",
-        "PNV",
-        "AGN",
-        "NUC",
-        "FRB"
+        "Other - Undefined",
+        "PSN - Possible SN",
+        "PNV - Possible Nova",
+        "AGN - Known AGN",
+        "NUC - Possibly nuclear",
+        "FRB - Fast Radio Burst event"
     ],
-    "object_types": {
+    "objtypes": {
         "23": "Afterglow",
         "29": "AGN",
         "1003": "Computed-Ia",
@@ -133,13 +133,13 @@
         "7": "floyds01",
         "11": "nres02"
     },
-    "telescopes": {
+    "archives": {
         "0": "1m0a.doma.elp.lco",
         "1": "1m0a.domb.cpt.lco",
         "4": "4m0a.doma.sor",
         "11": "TVLT: The Very Large Telescope"
     },
-    "archives": {
+    "telescopes": {
         "2": "DSS",
         "0": "Other",
         "1": "SDSS"

--- a/hermes/test/tns_options.json
+++ b/hermes/test/tns_options.json
@@ -133,13 +133,13 @@
         "7": "floyds01",
         "11": "nres02"
     },
-    "archives": {
+    "telescopes": {
         "0": "1m0a.doma.elp.lco",
         "1": "1m0a.domb.cpt.lco",
         "4": "4m0a.doma.sor",
         "11": "TVLT: The Very Large Telescope"
     },
-    "telescopes": {
+    "archives": {
         "2": "DSS",
         "0": "Other",
         "1": "SDSS"

--- a/hermes/tns.py
+++ b/hermes/tns.py
@@ -154,7 +154,7 @@ def convert_classification_hermes_message_to_tns(hermes_message, target_filename
 
             first_spectra = spectroscopy_by_target[target['name']][0]
             # Set classification object_type from the first spectrum
-            classification_report['objtypeid'] = str(tns_options.get('object_types', {}).get(first_spectra.get('classification'), -1))
+            classification_report['objtypeid'] = str(tns_options.get('objtypes', {}).get(first_spectra.get('classification'), -1))
             # Proprietary period of the classification uses the targets discovery info proprietary period but should be left to 0 usually
             classification_report['class_proprietary_period'] = {
                 'class_proprietary_period_value': str(discovery_info.get('proprietary_period', 0)),


### PR DESCRIPTION
This fixes TNS discovery submissions. There is still a bug I've reported to them that is breaking classification submissions (the /values/ api no longer returns `object_types` needed for classification string to id mapping). I've tested the discovery submission though on the TNS sandbox, and these changes should remove our use of the deprecated keys in the discovery report. 